### PR TITLE
sync from prod 2025-12-05

### DIFF
--- a/steamheadless/Chart.yaml
+++ b/steamheadless/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.2.0'
 description: description
 name: steamheadless
 type: application
-version: '1.0.18'
+version: '1.0.19'

--- a/steamheadless/OlaresManifest.yaml
+++ b/steamheadless/OlaresManifest.yaml
@@ -5,7 +5,7 @@ metadata:
   description: A Headless Steam Service
   icon: https://app.cdn.olares.com/appstore/steamheadless/icon.png
   appid: steamheadless
-  version: '1.0.18'
+  version: '1.0.19'
   title: Steam Headless
   categories:
   - Fun

--- a/steamheadless/owners
+++ b/steamheadless/owners
@@ -5,3 +5,4 @@ owners:
 - 'pengpeng'
 - 'harveyff'
 - 'zdf-org'
+- 'eball'

--- a/steamheadless/templates/steam.yaml
+++ b/steamheadless/templates/steam.yaml
@@ -1,14 +1,3 @@
-﻿{{- $ipfsDomainENV := split  ","  .Values.domain.steamheadlessaudio -}}
-{{- $webDomain := index $ipfsDomainENV "_0" -}}
-
-{{- $parts := split "." $webDomain }}
-{{- $subdomain := index $parts "_0" }}
-{{- $subdomain2 := split  $subdomain  .Values.domain.steamheadlessaudio -}}
-
-{{- $domain := index $subdomain2 "_0" }}
-{{- $domain2 := index $subdomain2 "_1" }}
-
-{{- $newWebDomain := printf "%s.local%s" $subdomain $domain2 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -78,7 +67,7 @@ spec:
             - name: PORT_AUDIO_WEBSOCKET
               value: "8088"
             - name: DOMAIN_AUDIO_WEBSOCKET
-              value: {{ $newWebDomain }}
+              value: {{ .Values.domain.steamheadlessaudio }}
             - name: PORT_NOVNC_WEB
               value: '8083'
             - name: NEKO_NAT1TO1
@@ -100,7 +89,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
-          image: "docker.io/bytetrade/steam-headless:v0.1.10"
+          image: beclab/steam-headless:v0.1.11
           livenessProbe:
             httpGet:
               path: /
@@ -184,27 +173,11 @@ spec:
         - name: steam-headless-claim0
           hostPath:
             type: DirectoryOrCreate
-            {{- if .Values.sysVersion }}
-              {{- if semverCompare ">=1.12.3-0" (toString .Values.sysVersion) }}
-            path: {{ .Values.userspace.appCache }}/c0
-              {{- else }}
             path: {{ .Values.userspace.appCache }}/{{ .Release.Name }}/c0
-              {{- end }}
-            {{- else }}
-            path: {{ .Values.userspace.appCache }}/{{ .Release.Name }}/c0
-            {{- end }}
         - name: steam-headless-claim1
           hostPath:
             type: DirectoryOrCreate
-            {{- if .Values.sysVersion }}
-              {{- if semverCompare ">=1.12.3-0" (toString .Values.sysVersion) }}
-            path: {{ .Values.userspace.appCache }}/c1
-              {{- else }}
             path: {{ .Values.userspace.appCache }}/{{ .Release.Name }}/c1
-              {{- end }}
-            {{- else }}
-            path: {{ .Values.userspace.appCache }}/{{ .Release.Name }}/c1
-            {{- end }}
         - name: input-devices
           hostPath:
             path: /dev/input/


### PR DESCRIPTION
## 同步内容

- f4d87452: [UPDATE][steamheadless][1.0.19] Bump sunshine version to v2025.1201.3826 (#1341) (by Teng)
- 56ffed8b: [UPDATE][adguardhome][1.0.2] (#1327) (by Teng)
- 94dc2690: [UPDATE][penpot][1.0.6] (#1339) (by Teng)


同步了 3 个提交。