### PR TITLE
[UPDATE][onlyofficev2][1.0.3] wait for jwtgeter to retrieving secret

### DIFF
--- a/onlyofficev2/Chart.yaml
+++ b/onlyofficev2/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.0.2"
+version: "1.0.3"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/onlyofficev2/OlaresManifest.yaml
+++ b/onlyofficev2/OlaresManifest.yaml
@@ -7,7 +7,7 @@ metadata:
   description: Run your private office with the ONLYOFFICE
   icon: https://app.cdn.olares.com/appstore/onlyoffice/icon.png
   appid: onlyofficev2
-  version: '1.0.2'
+  version: '1.0.3'
   title: OnlyOffice
   categories:
   - Productivity_v112

--- a/onlyofficev2/onlyofficev2/Chart.yaml
+++ b/onlyofficev2/onlyofficev2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: '1.25.3-2'
+appVersion: "1.25.3-2"
 description: description
 name: onlyofficev2
 type: application
-version: 1.0.2
+version: 1.0.3

--- a/onlyofficev2/onlyofficev2server/Chart.yaml
+++ b/onlyofficev2/onlyofficev2server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: '9.2.0'
+appVersion: "9.2.0"
 description: description
 name: onlyofficev2server
 type: application
-version: 1.0.2
+version: 1.0.3

--- a/onlyofficev2/onlyofficev2server/templates/client.yaml
+++ b/onlyofficev2/onlyofficev2server/templates/client.yaml
@@ -138,6 +138,16 @@ spec:
             mountPath: /home
         securityContext:
           runAsUser: 0
+      - name: wait-for-jwtgeter
+        image: "docker.io/beclab/wait-for:0.1.0"
+        args:
+          - '-it'
+          - >-
+            jwtgeter:3030
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        imagePullPolicy: IfNotPresent
       containers:
       - image: kldtks/onlyoffice-example-node:v1.6.10-amd64
         name: web


### PR DESCRIPTION
### PR Title 
> [UPDATE][onlyofficev2][1.0.3]

### App Title
> Wait for jwtgeter to start before retrieving cfgSignatureSecret

### Description
> The onlyofficeclient fails to retrieve cfgSignatureSecret during startup because jwtgeter has not started yet.

### Statement
- [ ] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
