### PR TITLE
[UPDATE][steamheadless][1.0.24] add deviceName support in deployment

### DIFF
--- a/steamheadless/Chart.yaml
+++ b/steamheadless/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.2.0'
 description: description
 name: steamheadless
 type: application
-version: '1.0.23'
+version: '1.0.24'

--- a/steamheadless/OlaresManifest.yaml
+++ b/steamheadless/OlaresManifest.yaml
@@ -5,7 +5,7 @@ metadata:
   description: A Headless Steam Service
   icon: https://app.cdn.olares.com/appstore/steamheadless/icon.png
   appid: steamheadless
-  version: '1.0.23'
+  version: '1.0.24'
   title: Steam Headless
   categories:
   - Fun

--- a/steamheadless/templates/steam.yaml
+++ b/steamheadless/templates/steam.yaml
@@ -85,11 +85,15 @@ spec:
               value: all
             - name: NVIDIA_VISIBLE_DEVICES
               value: all
+        {{- if .Values.deviceName }}
+            - name: DEVICE_NAME
+              value: {{ .Values.deviceName }}
+        {{- end }}  
             - name: NODE_IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
-          image: docker.io/beclab/steam-headless:v0.1.11
+          image: docker.io/beclab/steam-headless:v0.1.13
           livenessProbe:
             httpGet:
               path: /
@@ -176,6 +180,10 @@ spec:
               mountPath: /dev/input/
             - name: dshm
               mountPath: /dev/shm
+        {{- if and .Values.deviceName (eq .Values.deviceName "Olares One") }}
+            - name: snd
+              mountPath: /dev/snd
+        {{- end }}
       restartPolicy: Always
       volumes:
         - name: steam-headless-claim0
@@ -193,6 +201,12 @@ spec:
         - name: dshm
           emptyDir:
             medium: Memory
+    {{- if and .Values.deviceName (eq .Values.deviceName "Olares One") }}
+        - name: snd
+          hostPath:
+            path: /dev/snd
+            type: ''
+    {{- end }}
       securityContext:
         runAsUser: 0
 


### PR DESCRIPTION
### App Title
steamheadless

### Description
Add deviceName support in deployment
Add HDMI video and audio output support for Olares One

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
