### PR TITLE
[UPDATE][speaches][1.0.2]

### DIFF
--- a/speaches/Chart.yaml
+++ b/speaches/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: '1.0.1'
+version: '1.0.2'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/speaches/OlaresManifest.yaml
+++ b/speaches/OlaresManifest.yaml
@@ -7,7 +7,7 @@ metadata:
   description: OpenAI-compatible TTS/STT server
   appid: speaches
   title: Speaches
-  version: '1.0.1'
+  version: '1.0.2'
   categories:
     - Utilities
     - Productivity_v112

--- a/speaches/speaches/Chart.yaml
+++ b/speaches/speaches/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "1.25.3-2"
 description: Speaches client proxy
 name: speaches
 type: application
-version: 1.0.1
+version: 1.0.2

--- a/speaches/speachesserver/Chart.yaml
+++ b/speaches/speachesserver/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "0.8.2"
 description: Speaches server (shared)
 name: speachesserver
 type: application
-version: 1.0.1
+version: 1.0.2

--- a/speaches/speachesserver/templates/speaches.yaml
+++ b/speaches/speachesserver/templates/speaches.yaml
@@ -97,9 +97,17 @@ spec:
           {{- else }}
           image: "docker.io/beclab/speaches-ai-speaches:0.8.2-cpu"
           {{- end }}
+          command:
+            - sh
+            - '-c'
+            - |
+              uv tool install huggingface-hub 2>/dev/null || true
+              exec uvicorn --factory speaches.main:create_app
           env:
             - name: HF_HUB_CACHE
               value: "/home/ubuntu/.cache/huggingface/hub"
+            - name: HF_HUB_DISABLE_XET
+              value: "1"
             - name: LOOPBACK_HOST_URL
               value: "http://localhost:8000"
             - name: CHAT_COMPLETION_BASE_URL


### PR DESCRIPTION
### App Title
> Speaches

### Description
> pre-install hf for terminal using instead of deprecated huggingface-cli

### Statement
- [ ] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
