### PR TITLE
[UPDATE][tensorzero][1.0.5]

### DIFF
--- a/tensorzero/Chart.yaml
+++ b/tensorzero/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2026.3.0"
+appVersion: "2026.4.0"

--- a/tensorzero/OlaresManifest.yaml
+++ b/tensorzero/OlaresManifest.yaml
@@ -5,7 +5,7 @@ metadata:
   description: Open-source stack for industrial-grade LLM applications
   icon: https://app.cdn.olares.com/appstore/tensorzero/icon.png
   appid: tensorzero
-  version: '1.0.4'
+  version: '1.0.5'
   title: TensorZero
   categories:
   - Utilities_v112
@@ -16,7 +16,7 @@ permission:
   userData:
   - Home
 spec:
-  versionName: '2026.3.0'
+  versionName: '2026.4.0'
   promoteImage:
     - https://app.cdn.olares.com/appstore/tensorzero/1.webp
     - https://app.cdn.olares.com/appstore/tensorzero/2.webp
@@ -43,8 +43,8 @@ spec:
   locale:
   - en-US
   - zh-CN
-  requiredMemory: 1.5Gi
-  limitedMemory: 7Gi
+  requiredMemory: 1.75Gi
+  limitedMemory: 7.5Gi
   requiredDisk: 512Mi
   limitedDisk: 2Gi
   requiredCpu: 0.5
@@ -54,6 +54,12 @@ spec:
   - amd64
   - arm64
 options:
+  # Disable Olares gateway-level request timeout. TensorZero's /inference
+  # proxies long LLM calls (large context, reasoning models, slow self-hosted
+  # providers) that can routinely exceed Olares' default ~60s cap. Setting 0
+  # delegates timeout enforcement to the in-app openresty (see ingress.yaml,
+  # which uses 300s) instead of failing fast at the platform edge.
+  apiTimeout: 0
   dependencies:
   - name: olares
     type: system

--- a/tensorzero/templates/configmap.yaml
+++ b/tensorzero/templates/configmap.yaml
@@ -61,8 +61,12 @@ data:
     done
     sleep 2
 
+    # Note: `--enable-optimization-postgres-migrations` existed up to gateway
+    # 2026.3.x and was removed in 2026.4.0 (all postgres migrations, including
+    # the optimization-related tables, are now handled by a single
+    # `--run-postgres-migrations`). Keep only the unified flag going forward.
     echo "Running database migrations..."
-    gateway --run-postgres-migrations --enable-optimization-postgres-migrations
+    gateway --run-postgres-migrations
 
     echo "Running clickhouse migrations..."
     gateway --run-clickhouse-migrations

--- a/tensorzero/templates/ingress.yaml
+++ b/tensorzero/templates/ingress.yaml
@@ -11,12 +11,16 @@ data:
       access_log /opt/bitnami/openresty/nginx/logs/access.log;
       error_log /opt/bitnami/openresty/nginx/logs/error.log;
 
-      # Support large file uploads
+      # Support large file uploads (eval datasets, optimization batches, etc.)
       client_max_body_size 100m;
 
+      # Server-level timeouts. LLM gateway traffic dominates this proxy and is
+      # intrinsically long-tail: large context + slow providers + reasoning
+      # models can run multi-minute. Server-default values are floors that
+      # individual locations can override.
       proxy_connect_timeout                          30s;
-      proxy_send_timeout                             60s;
-      proxy_read_timeout                             180s;
+      proxy_send_timeout                             300s;
+      proxy_read_timeout                             300s;
       proxy_set_header      host                      $host;
       proxy_set_header      x-forwarded-host          $http_host;
       proxy_set_header      x-real-ip                 $remote_addr;
@@ -27,23 +31,208 @@ data:
       proxy_set_header upgrade $http_upgrade;
       proxy_set_header connection "upgrade";
 
+      # === Routing policy ===
+      #
+      # Two backends share this single public entrance:
+      #   - gateway (port 3000): the actual TensorZero gateway — LLM inference,
+      #     feedback, datasets, optimization, evaluations, MCP, ops, ...
+      #   - ui (port 4000): the TensorZero Web UI (react-router SSR app)
+      #
+      # Every gateway-owned path is listed as its own `location` below; the
+      # default `location /` falls through to the UI. We derived the gateway
+      # route set from `crates/gateway/src/routes/external.rs` in the upstream
+      # repo and cross-checked it against the UI's `app/routes.ts` to make
+      # sure no prefix is ambiguous:
+      #
+      #   - UI uses   /datasets/, /optimization/supervised-fine-tuning/,
+      #               /workflow-evaluations/ (hyphen), /autopilot/, /playground,
+      #               /observability/, /api-keys, /config, /api/, /health
+      #   - Gateway uses  /inference, /batch_inference, /feedback, /openai/,
+      #                   /v1/ (inferences | datasets | optimization/gepa),
+      #                   /experimental_optimization*, /workflow_evaluation_run
+      #                   (underscore), /metrics, /status, /mcp
+      #
+      # `/internal/*` is intentionally NOT exposed: the UI calls it from its
+      # SSR loaders in-cluster (http://tensorzero:3000), there is no reason to
+      # let external clients reach it.
+      #
+      # `/health` collides by name: gateway returns JSON, UI serves a React
+      # page. We keep `/health` on the UI (human-facing); anything that needs
+      # gateway's JSON healthcheck externally should hit `/status` instead.
+      #
+      # Streaming endpoints (SSE): /inference, /openai/v1/chat/completions,
+      # /mcp. For those we MUST disable proxy_buffering / proxy_cache and turn
+      # chunked_transfer_encoding on, otherwise nginx accumulates the whole
+      # response, clients see a hang followed by a single blob, and truly long
+      # generations can be dropped. For non-streaming JSON endpoints we leave
+      # buffering at its default.
+
+      # -- TensorZero-native inference (SSE when stream=true) -----------------
       location /inference {
-          proxy_pass http://tensorzero:3000/inference;
+          proxy_pass http://tensorzero:3000;
           proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
           proxy_connect_timeout 60s;
-          proxy_read_timeout 60s;
-          proxy_send_timeout 180s;
-          # Support large file uploads
+          proxy_read_timeout 300s;
+          proxy_send_timeout 300s;
+
+          # Critical for SSE/streaming - disable response buffering
+          proxy_buffering off;
+          proxy_cache off;
+          chunked_transfer_encoding on;
+
           client_max_body_size 100m;
       }
 
+      # -- OpenAI-compatible surface (chat/completions + embeddings) ----------
+      # This is what 3rd-party tools (OpenCode, AgentZero, OpenNotebook, any
+      # LangChain/LlamaIndex-based app, etc.) hit when they want TensorZero to
+      # act as a drop-in LLM proxy. Clients set their OpenAI `base_url` to
+      # https://<entrance>/openai/v1 and TensorZero transparently routes to
+      # whichever provider is configured behind the model alias.
+      # chat/completions streams exactly like /inference; embeddings returns a
+      # single JSON body but the extra syscalls from `proxy_buffering off` are
+      # negligible compared to the benefit of never accidentally blocking SSE.
+      location /openai/ {
+          proxy_pass http://tensorzero:3000;
+          proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
+          proxy_connect_timeout 60s;
+          proxy_read_timeout 300s;
+          proxy_send_timeout 300s;
+
+          proxy_buffering off;
+          proxy_cache off;
+          chunked_transfer_encoding on;
+
+          client_max_body_size 100m;
+      }
+
+      # -- MCP (Streamable HTTP, long-lived SSE) ------------------------------
+      # MCP HTTP transport keeps a persistent SSE channel for server->client
+      # push; read/send timeouts are set to 1h to let a single client working
+      # session live its natural life. proxy_next_upstream is deliberately NOT
+      # set: retrying a half-open MCP stream would replay tool calls.
+      #
+      # DNS-rebinding protection bypass: gateway delegates /mcp to rmcp's
+      # StreamableHttpService, whose default allowed_hosts is hardcoded to
+      # ["localhost","127.0.0.1","::1"] and rejects every other Host with 421.
+      # TensorZero 2026.4.0 does not yet expose this allowlist as config, so
+      # we rewrite Host at the proxy boundary. Drop the override if a future
+      # gateway release lets us pass an allowed_hosts list via config/env.
+      location /mcp {
+          proxy_pass http://tensorzero:3000;
+          proxy_set_header Host 127.0.0.1;
+
+          proxy_connect_timeout 60s;
+          proxy_read_timeout 3600s;
+          proxy_send_timeout 3600s;
+
+          proxy_buffering off;
+          proxy_cache off;
+          chunked_transfer_encoding on;
+
+          client_max_body_size 100m;
+      }
+
+      # -- Batch inference (POST to launch, GET to poll) ----------------------
+      # Batch payloads can be significantly larger than a single prompt, so we
+      # raise client_max_body_size here; polling is cheap but we still allow
+      # the same 5min window for the launch call to finish persisting.
+      location /batch_inference {
+          proxy_pass http://tensorzero:3000;
+          proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
+          proxy_connect_timeout 60s;
+          proxy_read_timeout 300s;
+          proxy_send_timeout 300s;
+
+          client_max_body_size 1000m;
+      }
+
+      # -- Workflow evaluation runs (long-running) ----------------------------
+      # Evaluation runs block until the whole run completes. 30min is chosen
+      # as a practical ceiling that covers typical model grading jobs without
+      # letting genuinely stuck requests pile up forever.
+      location /workflow_evaluation_run {
+          proxy_pass http://tensorzero:3000;
+          proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
+          proxy_connect_timeout 60s;
+          proxy_read_timeout 1800s;
+          proxy_send_timeout 1800s;
+
+          client_max_body_size 100m;
+      }
+
+      # -- Experimental optimization workflows --------------------------------
+      # The launch endpoint returns a handle quickly; the poll endpoint may
+      # wait on a running job. Workflows themselves run asynchronously in the
+      # gateway, so 5min read is more than enough for the HTTP round-trip.
+      location /experimental_optimization {
+          proxy_pass http://tensorzero:3000;
+          proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
+          proxy_connect_timeout 60s;
+          proxy_read_timeout 300s;
+          proxy_send_timeout 300s;
+
+          client_max_body_size 100m;
+      }
+
+      # -- Stable /v1/ API family ---------------------------------------------
+      # Covers:
+      #   /v1/inferences/{list_inferences,get_inferences}  (ClickHouse queries)
+      #   /v1/datasets/{name}/...                          (datapoint CRUD)
+      #   /v1/optimization/gepa[/{task_id}]                (GEPA launch/poll)
+      # All non-streaming JSON; 5min is generous for the heaviest of these
+      # (list_inferences over a very large ClickHouse window).
+      location /v1/ {
+          proxy_pass http://tensorzero:3000;
+          proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
+          proxy_connect_timeout 60s;
+          proxy_read_timeout 300s;
+          proxy_send_timeout 300s;
+
+          client_max_body_size 100m;
+      }
+
+      # -- Feedback ingestion (small POST, fast) ------------------------------
+      location /feedback {
+          proxy_pass http://tensorzero:3000;
+          proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
+          proxy_connect_timeout 30s;
+          proxy_read_timeout 60s;
+          proxy_send_timeout 60s;
+
+          client_max_body_size 10m;
+      }
+
+      # -- Prometheus metrics scrape ------------------------------------------
+      location /metrics {
+          proxy_pass http://tensorzero:3000;
+          proxy_connect_timeout 10s;
+          proxy_read_timeout 30s;
+          proxy_send_timeout 30s;
+      }
+
+      # -- Gateway status JSON (external healthcheck) -------------------------
+      # `/health` is intentionally NOT proxied here (see header comment); if
+      # you need gateway's JSON healthcheck from the outside, hit /status.
+      location /status {
+          proxy_pass http://tensorzero:3000;
+          proxy_connect_timeout 5s;
+          proxy_read_timeout 10s;
+          proxy_send_timeout 10s;
+      }
+
+      # -- Web UI (default fallback) ------------------------------------------
+      # Mostly normal HTML/JSON traffic, but observability pages can issue
+      # slow ClickHouse-backed queries via SSR loaders; bumping read/send to
+      # 300s prevents 504s on those screens. UI itself doesn't stream, so we
+      # leave proxy_buffering at its default (on) here.
       location / {
           proxy_pass http://tensorzero:4000;
           proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
           proxy_connect_timeout 60s;
-          proxy_read_timeout 60s;
-          proxy_send_timeout 180s;
-          # Support large file uploads
+          proxy_read_timeout 300s;
+          proxy_send_timeout 300s;
+
           client_max_body_size 100m;
       }
     }
@@ -113,7 +302,7 @@ spec:
             failureThreshold: 10
           resources:
             limits:
-              cpu: 100m
+              cpu: 300m
               memory: 256Mi
             requests:
               cpu: 10m

--- a/tensorzero/templates/tensorzero.yaml
+++ b/tensorzero/templates/tensorzero.yaml
@@ -1,4 +1,4 @@
-﻿
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -34,7 +34,13 @@ spec:
               mkdir -p /var/lib/clickhouse
               chown -R 1000:1000 /var/lib/clickhouse
               chmod -R 755 /var/lib/clickhouse
-          resources: { }
+          resources:
+            limits:
+              cpu: 100m
+              memory: 64Mi
+            requests:
+              cpu: 10m
+              memory: 16Mi
           volumeMounts:
             - name: tensorzero-data
               mountPath: /var/lib/clickhouse
@@ -59,8 +65,8 @@ spec:
               cpu: 2
               memory: 4Gi
             requests:
-              cpu: 100m
-              memory: 500Mi
+              cpu: 200m
+              memory: 1Gi
           ports:
             - containerPort: 8123
               name: ch-http
@@ -90,15 +96,15 @@ spec:
             timeoutSeconds: 1
 
         - name: gateway
-          image: docker.io/beclab/tensorzero-gateway:2026.3.0
+          image: docker.io/beclab/tensorzero-gateway:2026.4.0
           command: ["/bin/bash", "/etc/gateway/start.sh"]
           resources:
             limits:
               cpu: 1
-              memory: 512Mi
+              memory: 1Gi
             requests:
               cpu: 100m
-              memory: 64Mi
+              memory: 128Mi
           ports:
             - containerPort: 3000
               name: gateway
@@ -112,23 +118,33 @@ spec:
             - name: gateway-startups
               mountPath: /etc/gateway/env.sh
               subPath: env.sh
+          # Postgres + ClickHouse migrations can take 60s+ on a cold start.
+          # startupProbe gives the gateway up to 5 minutes (30 * 10s) to come
+          # up before the liveness probe takes over, avoiding spurious restarts.
+          startupProbe:
+            httpGet:
+              path: /status
+              port: 3000
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /status
               port: 3000
             initialDelaySeconds: 30
             periodSeconds: 10
-            timeoutSeconds: 1
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /status
               port: 3000
-            initialDelaySeconds: 30
+            initialDelaySeconds: 5
             periodSeconds: 10
-            timeoutSeconds: 1
+            timeoutSeconds: 5
 
         - name: ui
-          image: docker.io/beclab/tensorzero-ui:2026.3.0
+          image: docker.io/beclab/tensorzero-ui:2026.4.0
           env:
             - name: TENSORZERO_GATEWAY_URL
               value: "http://localhost:3000"


### PR DESCRIPTION
### App Title
> TensorZero

### Description
> upgrade tensorzero from 2026.3.0 to 2026.4.0
   open all tensorzero apis for using including new added mcp in 2026.4.0
   calibrate resource requests and limits

### Statement
- [ ] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
