### PR TITLE
[UPDATE][speaches][1.0.12] Remove nvidia.com/gpu from config template

### DIFF
--- a/speaches/Chart.yaml
+++ b/speaches/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/speaches/OlaresManifest.yaml
+++ b/speaches/OlaresManifest.yaml
@@ -7,7 +7,7 @@ metadata:
   description: OpenAI-compatible TTS/STT server
   appid: speaches
   title: Speaches
-  version: '1.0.11'
+  version: '1.0.12'
   categories:
     - Utilities_v112
     - AI

--- a/speaches/speaches/Chart.yaml
+++ b/speaches/speaches/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "1.25.3-2"
 description: Speaches client proxy
 name: speaches
 type: application
-version: 1.0.11
+version: 1.0.12

--- a/speaches/speachesserver/Chart.yaml
+++ b/speaches/speachesserver/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "0.8.2"
 description: Speaches server (shared)
 name: speachesserver
 type: application
-version: 1.0.11
+version: 1.0.12

--- a/speaches/speachesserver/templates/speaches.yaml
+++ b/speaches/speachesserver/templates/speaches.yaml
@@ -332,11 +332,9 @@ spec:
             limits:
               cpu: "8"
               memory: 8Gi
-              nvidia.com/gpu: 1
             requests:
               cpu: 500m
               memory: 2Gi
-              nvidia.com/gpu: 1
             {{- else }}
             limits:
               cpu: "8"


### PR DESCRIPTION
## Changes
- Remove nvidia.com/gpu: 1 from config template (both limits and requests)
- Bump chart version: 1.0.11 → 1.0.12

## Testing
- [ ] Deploy to test environment