### PR TITLE
[UPDATE][claudecode][0.1.2]expand base image with dev runtimes and tooling

### DIFF
--- a/claudecode/Chart.yaml
+++ b/claudecode/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '2.1.117'
 description: Anthropic's official agentic coding CLI that lives in your terminal
 name: claudecode
 type: application
-version: 0.1.1
+version: 0.1.2

--- a/claudecode/OlaresManifest.yaml
+++ b/claudecode/OlaresManifest.yaml
@@ -1,3 +1,4 @@
+---
 olaresManifest.version: '0.11.0'
 olaresManifest.type: app
 metadata:
@@ -6,7 +7,7 @@ metadata:
   description: Anthropic's official agentic coding CLI that lives in your terminal
   appid: claudecode
   title: Claude Code
-  version: 0.1.1
+  version: 0.1.2
   categories:
   - Developer Tools
   - Productivity_v112
@@ -30,6 +31,7 @@ spec:
     - Real file edits, shell execution, git workflows, and test runs driven by natural language.
     - Skills, Subagents and MCP-compatible tool calling.
     - Works with a Claude Pro/Max subscription (OAuth) or a Console API key; also supports Amazon Bedrock and Google Vertex AI.
+    - Workspace image ships common language runtimes and build toolchains (Python, Node.js, Go, Rust, OpenJDK 21, Ruby, PHP, Lua) plus database clients (PostgreSQL, MySQL/MariaDB, Redis), git-lfs, protobuf compiler, Gradle, tmux, dig/ss/nc, shellcheck, clang-format/tidy, graphviz, and extra -dev headers (libpq, MySQL client, curl, ICU, LDAP) so agents can run typical dev commands without root.
 
     **First-time Setup**
     Open the `Claude Code CLI` entrance and run `claude` to launch the OAuth login flow, or set `ANTHROPIC_API_KEY` in the app environment variables and restart.

--- a/claudecode/docker/Dockerfile
+++ b/claudecode/docker/Dockerfile
@@ -1,19 +1,21 @@
 # Claude Code base image for Olares.
 #
-# Scope: a thin Ubuntu 24.04 base with the minimum toolbox a Claude Code
-# terminal user expects (curl / git / less / procps / vim / jq), plus a
-# non-root user (UID 1000) so the runtime Pod never needs root.
+# Scope: Ubuntu 24.04 with common CLI deps, language runtimes / build
+# toolchains (Python / Node / Go / Rust / Java / Ruby / PHP / Lua),
+# database clients, protobuf, Gradle, and extra -dev headers for
+# typical agent-driven dev work. Non-root user (UID 1000) runs the Pod.
 #
 # The claude binary itself is NOT baked into this image. It is installed
 # at runtime by the init-install-claude initContainer into the shared
 # /opt/data PVC (under ~/.local/bin/claude + ~/.local/share/claude/).
-# That keeps base-image size small and lets us bump claude-code versions
-# without rebuilding the image.
+#
+# ripgrep is NOT installed here: claude ships its own bundled copy and
+# installing the system one alongside can confuse its search feature.
 #
 # Build & push:
 #   docker buildx build \
 #     --platform linux/amd64,linux/arm64 \
-#     -t beclab/harveyff-claudecode-base:0.1.0 \
+#     -t beclab/harveyff-claudecode-base:0.2.0 \
 #     --push .
 FROM ubuntu:24.04
 
@@ -21,22 +23,99 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 
-# Core toolbox expected by a Claude Code terminal user. ripgrep is NOT
-# installed here: claude ships its own bundled copy and installing the
-# system one alongside can confuse its search feature.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         git \
+        git-lfs \
+        openssh-client \
         jq \
+        yq \
         less \
         locales \
         procps \
         tzdata \
         unzip \
+        zip \
         vim-tiny \
+        wget \
         xz-utils \
+        pigz \
+        file \
+        rsync \
+        patch \
+        pkg-config \
+        build-essential \
+        cmake \
+        ninja-build \
+        clang \
+        clang-format \
+        clang-tidy \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3-venv \
+        pipx \
+        nodejs \
+        npm \
+        golang-go \
+        rustc \
+        cargo \
+        ruby \
+        ruby-dev \
+        ruby-bundler \
+        openjdk-21-jdk-headless \
+        maven \
+        gradle \
+        php8.3-cli \
+        php8.3-curl \
+        php8.3-intl \
+        php8.3-mbstring \
+        php8.3-mysql \
+        php8.3-pgsql \
+        php8.3-sqlite3 \
+        php8.3-xml \
+        php8.3-zip \
+        composer \
+        lua5.4 \
+        sqlite3 \
+        gfortran \
+        postgresql-client \
+        default-mysql-client \
+        redis-tools \
+        protobuf-compiler \
+        libprotobuf-dev \
+        libssl-dev \
+        libffi-dev \
+        zlib1g-dev \
+        libbz2-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+        liblzma-dev \
+        libxml2-dev \
+        libxslt1-dev \
+        libyaml-dev \
+        libjpeg-turbo8-dev \
+        libpng-dev \
+        libcurl4-openssl-dev \
+        libicu-dev \
+        libldap2-dev \
+        libpq-dev \
+        default-libmysqlclient-dev \
+        gettext \
+        perl \
+        tmux \
+        htop \
+        dnsutils \
+        iproute2 \
+        netcat-openbsd \
+        socat \
+        xmlstarlet \
+        shellcheck \
+        graphviz \
+        moreutils \
+ && ln -sfn "/usr/lib/jvm/java-21-openjdk-$(dpkg --print-architecture)" /usr/lib/jvm/java-21-openjdk-current \
  && rm -rf /var/lib/apt/lists/* \
  && locale-gen C.UTF-8 \
  && (userdel -r ubuntu 2>/dev/null || true) \
@@ -45,12 +124,15 @@ RUN apt-get update \
  && mkdir -p /opt/data \
  && chown -R 1000:1000 /opt/data
 
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-current
+
 USER 1000:1000
 WORKDIR /opt/data
 
 ENV HOME=/opt/data \
     PATH=/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     TERM=xterm-256color \
-    DISABLE_AUTOUPDATER=1
+    DISABLE_AUTOUPDATER=1 \
+    PIP_BREAK_SYSTEM_PACKAGES=1
 
 CMD ["bash"]

--- a/claudecode/docker/README.md
+++ b/claudecode/docker/README.md
@@ -1,28 +1,51 @@
 # claudecode base image
 
-A thin Ubuntu 24.04 base image for the Olares `claudecode` app.
+Ubuntu 24.04 base image for the Olares `claudecode` app with common language
+runtimes, build toolchains, database clients, and extra dev headers pre-installed.
 
 ## What it ships
 
-- `ca-certificates`, `curl`, `git`, `jq`, `less`, `procps`, `tzdata`,
-  `unzip`, `vim-tiny`, `xz-utils`, `locales` (C.UTF-8 pre-generated).
-- A non-root user `claude` (UID 1000) with `HOME=/opt/data` and
-  `PATH` prepending `/opt/data/.local/bin`.
-- No `claude` binary. The binary is installed at runtime by the
-  `init-install-claude` initContainer into the shared PVC so bumping
-  claude-code versions does not require rebuilding this image.
+**Shell / tooling:** `ca-certificates`, `curl`, `wget`, `git`, `git-lfs`,
+`openssh-client`, `jq`, `yq` (kislyuk YAML CLI), `less`, `procps`, `tzdata`,
+`unzip`, `zip`, `vim-tiny`, `xz-utils`, `pigz`, `file`, `rsync`, `patch`,
+`tmux`, `htop`, `dnsutils`, `iproute2`, `netcat-openbsd`, `socat`, `xmlstarlet`,
+`shellcheck`, `graphviz`, `moreutils`, `locales` (C.UTF-8 pre-generated).
+
+**Build:** `build-essential`, `pkg-config`, `cmake`, `ninja-build`, `clang`,
+`clang-format`, `clang-tidy`, common `-dev` headers (SSL, FFI, zlib, bz2,
+readline, sqlite, lzma, xml, xslt, yaml, jpeg, png, **curl**, **ICU**, **LDAP**,
+**libpq**, **default-libmysqlclient-dev**), `gettext`, `protobuf-compiler`,
+`libprotobuf-dev`, `gfortran`.
+
+**Runtimes (distro):** Python 3 (`python3`, `pip`, `venv`, `pipx`), Node.js +
+`npm`, Go (`golang-go`), Rust (`rustc`, `cargo`), Ruby + `bundler`, OpenJDK 21
+(headless JDK), `maven`, **Gradle**, PHP 8.3 CLI + extensions (`curl`, `intl`,
+`mysql`, `pgsql`, `sqlite3`, `mbstring`, `xml`, `zip`) + `composer`, `lua5.4`,
+`sqlite3`, `perl`.
+
+**Database clients:** `postgresql-client`, `default-mysql-client`,
+`redis-tools`.
+
+**User:** non-root `claude` (UID 1000), `HOME=/opt/data`, `PATH` prepends
+`/opt/data/.local/bin`. `JAVA_HOME` points at OpenJDK 21.
+`PIP_BREAK_SYSTEM_PACKAGES=1` so `pip install` into the distro Python is
+allowed when needed.
+
+**Not included:** the `claude` CLI binary (installed at runtime by
+`init-install-claude` into the shared PVC). `ripgrep` is omitted on purpose:
+Claude Code bundles its own.
 
 ## Build & push
 
 ```bash
 # Single-arch (local dev)
-docker build -t beclab/harveyff-claudecode-base:0.1.0 .
+docker build -t beclab/harveyff-claudecode-base:0.2.0 .
 
 # Multi-arch release (recommended, matches chart supportArch)
 docker buildx create --use --name claudecode-builder || true
 docker buildx build \
   --platform linux/amd64,linux/arm64 \
-  -t beclab/harveyff-claudecode-base:0.1.0 \
+  -t beclab/harveyff-claudecode-base:0.2.0 \
   --push .
 ```
 
@@ -30,13 +53,13 @@ docker buildx build \
 
 When bumping apt dependencies or base Ubuntu:
 
-1. Increment the tag: `0.1.0 -> 0.1.1` (or major if breaking).
-2. Update both references in
-   `claudecode/templates/deployment.yaml` (initContainer + main container).
-3. Bump `version` in `claudecode/Chart.yaml`.
+1. Increment the tag (e.g. `0.2.0 -> 0.2.1`).
+2. Update both references in `claudecode/templates/deployment.yaml`
+   (initContainer + main container).
+3. Bump `version` in `claudecode/Chart.yaml` and `metadata.version` in
+   `OlaresManifest.yaml`.
 
 The `claude` binary itself (v2.1.117 etc.) is controlled separately by
-`appVersion` in `Chart.yaml` and `metadata.version` /
-`spec.versionName` in `OlaresManifest.yaml`; it is pulled fresh by the
-init container whenever `$HOME/.install-state/install-complete` is
-missing, regardless of base image tag.
+`appVersion` in `Chart.yaml` and `metadata.version` / `spec.versionName` in
+`OlaresManifest.yaml`; it is pulled fresh by the init container whenever
+`$HOME/.install-state/install-complete` is missing, regardless of base image tag.

--- a/claudecode/i18n/en-US/OlaresManifest.yaml
+++ b/claudecode/i18n/en-US/OlaresManifest.yaml
@@ -11,6 +11,7 @@ spec:
     - Real file edits, shell execution, git workflows, and test runs driven by natural language.
     - Skills, Subagents and MCP-compatible tool calling.
     - Works with a Claude Pro/Max subscription (OAuth) or a Console API key; also supports Amazon Bedrock and Google Vertex AI.
+    - Workspace image ships common language runtimes and build toolchains (Python, Node.js, Go, Rust, OpenJDK 21, Ruby, PHP, Lua) plus database clients (PostgreSQL, MySQL/MariaDB, Redis), git-lfs, protobuf compiler, Gradle, tmux, dig/ss/nc, shellcheck, clang-format/tidy, graphviz, and extra -dev headers (libpq, MySQL client, curl, ICU, LDAP) so agents can run typical dev commands without root.
 
     **First-time Setup**
     Open the `Claude Code CLI` entrance and run `claude` to launch the OAuth login flow, or set `ANTHROPIC_API_KEY` in the app environment variables and restart.

--- a/claudecode/i18n/zh-CN/OlaresManifest.yaml
+++ b/claudecode/i18n/zh-CN/OlaresManifest.yaml
@@ -11,6 +11,7 @@ spec:
     - 可通过自然语言直接编辑文件、执行 shell 命令、管理 Git 工作流及运行测试。
     - 支持 Skills、Subagents 及 MCP 兼容工具调用。
     - 兼容 Claude Pro/Max 订阅（OAuth 登录）或 Console API Key，同时支持 Amazon Bedrock 和 Google Vertex AI。
+    - 工作区镜像预装常见语言运行时与构建工具链（Python、Node.js、Go、Rust、OpenJDK 21、Ruby、PHP、Lua），以及数据库客户端（PostgreSQL、MySQL/MariaDB、Redis）、git-lfs、protobuf 编译器、Gradle、tmux、dig/ss/nc、shellcheck、clang-format/tidy、graphviz，以及各类常见 -dev 头文件（libpq、MySQL 客户端、curl、ICU、LDAP）等，便于在无 root 下完成常见开发任务。
 
     **首次使用设置**
     打开 `Claude Code CLI` 入口并运行 `claude` 启动 OAuth 登录流程，或在应用环境变量中设置 `ANTHROPIC_API_KEY` 并重启应用。

--- a/claudecode/templates/deployment.yaml
+++ b/claudecode/templates/deployment.yaml
@@ -1,23 +1,3 @@
-# Claude Code on Olares
-#
-# Architecture:
-#   - Base image: beclab/harveyff-claudecode-base (Ubuntu 24.04 with
-#     common CLI deps pre-installed, non-root user UID 1000 baked in).
-#   - initContainers:
-#       * init-chmod-data (root): ensures /opt/data is owned by 1000:1000.
-#       * init-install-claude (UID 1000): installs the claude native
-#         binary into /opt/data/.local/bin/ via https://claude.ai/install.sh
-#         on first run, then leaves a sentinel so subsequent restarts
-#         skip the download and start instantly.
-#   - Main container runs as UID 1000 with all Linux capabilities
-#     dropped and privilege escalation forbidden. The entrypoint is
-#     `sleep infinity`; the real work happens when the Olares terminal
-#     entrance kubectl-execs into this container.
-#   - /opt/data is the single source of truth: ~/.claude (sessions,
-#     skills, plugins), ~/.claude.json (OAuth login + project list),
-#     and .local/share/claude/<version>/ (the versioned native binary).
-#     All persisted through the app-data-home hostPath volume.
-#   - Auto-updates are disabled; upgrades go through chart version bumps.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -71,7 +51,7 @@ spec:
         # only writes under $HOME. A sentinel file makes subsequent
         # Pod starts skip the download.
         - name: init-install-claude
-          image: "beclab/harveyff-claudecode-base:0.1.0"
+          image: "beclab/harveyff-claudecode-base:0.3.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
@@ -83,6 +63,8 @@ spec:
           env:
             - name: HOME
               value: /opt/data
+            - name: JAVA_HOME
+              value: /usr/lib/jvm/java-21-openjdk-current
             - name: DISABLE_AUTOUPDATER
               value: "1"
           command:
@@ -136,7 +118,7 @@ spec:
         # login / non-login / interactive / non-interactive shells all
         # see the claude binary on PATH.
         - name: claudecode
-          image: "beclab/harveyff-claudecode-base:0.1.0"
+          image: "beclab/harveyff-claudecode-base:0.3.0"
           imagePullPolicy: IfNotPresent
           workingDir: /opt/data
           securityContext:
@@ -153,6 +135,8 @@ spec:
               value: xterm-256color
             - name: HOME
               value: /opt/data
+            - name: JAVA_HOME
+              value: /usr/lib/jvm/java-21-openjdk-current
             - name: PATH
               value: "/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
             - name: DISABLE_AUTOUPDATER


### PR DESCRIPTION
- Dockerfile: Python/Node/Go/Rust/Java/Ruby/PHP/Lua, Maven/Gradle, DB clients (psql/mysql/redis-cli), protobuf, git-lfs, clang-format/tidy, common -dev headers, tmux, jq/yq, shellcheck, graphviz, and related CLI utilities.

- deployment: beclab/harveyff-claudecode-base:0.2.0; set JAVA_HOME for init-install-claude and main container.

- OlaresManifest, i18n, docker/README: document the workspace toolchain; bump chart to 0.1.2.

### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
> The title of your application appears on Market.

### Description
> Brief description about your application here. 
>
> For app updates, please describe the changes.

### Statement
- [ ] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
