### PR TITLE
[UPDATE][radicale][1.0.7]

### DIFF
--- a/radicale/Chart.yaml
+++ b/radicale/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.1.8"
+appVersion: "3.7.3"

--- a/radicale/OlaresManifest.yaml
+++ b/radicale/OlaresManifest.yaml
@@ -5,14 +5,14 @@ metadata:
   description: Free and Open-Source CalDAV and CardDAV Server
   icon: https://app.cdn.olares.com/appstore/radicale/icon.png
   appid: radicale
-  version: '1.0.6'
+  version: '1.0.7'
   title: Radicale
   categories:
   - Productivity_v112
   - Productivity
-  - Utilities  
+  - Utilities
 spec:
-  versionName: 3.1.8
+  versionName: 3.7.3
   promoteImage:
   - https://app.cdn.olares.com/appstore/radicale/1.webp
   - https://app.cdn.olares.com/appstore/radicale/2.webp
@@ -35,8 +35,22 @@ spec:
     - Is GPLv3-licensed free software.
 
   upgradeDescription: |
+    v1.0.7 (Radicale 3.1.1 → 3.7.3)
+    - New: collection sharing via map or token, including management API and WebUI extension
+    - New: share an address book as a birthday calendar
+    - New: server option `delay_on_error` and logging option `limit_content`
+    - New: stricter `Content-Security-Policy` header by default on fresh configs
+    - New: `validate_user_value` / `validate_path_value` for safer filesystems
+    - Improved: WebUI refactor, smaller JS modules, better caching and error handling
+    - Improved: `path_to_filesystem()` performance and access-rights preload
+    - Improved: enforce `max_resource_size` on storage discover/get
+    - Fixed: MOVE with URL-encoded Destination header
+    - Fixed: sharing/PROPFIND/PROPPATCH permission checks and storage hook on delete
+    - Dependency: replaced unmaintained `passlib` with `libpass >= 1.9.3`, compatible with bcrypt 5.x
+
+    v1.0.6 (Radicale 3.1.x)
     - Fix setuptools requirement if installing wheel
-    - Tests: Switch from python setup.py test to tox
+    - Tests: switch from `python setup.py test` to tox
     - Small changes to build system configuration and tests
 
   developer: Kozea Community
@@ -46,12 +60,12 @@ spec:
   locale:
   - en-US
   - zh-CN
-  requiredMemory: 64Mi
-  limitedMemory: 128Mi
-  requiredDisk: 128Mi
-  limitedDisk: 256Mi
-  requiredCpu: 0.1
-  limitedCpu: 0.5
+  requiredMemory: 512Mi
+  limitedMemory: 2Gi
+  requiredDisk: 256Mi
+  limitedDisk: 2Gi
+  requiredCpu: 0.25
+  limitedCpu: 1
   doc: https://radicale.org/v3.html
   license:
   - text: GPL-3.0
@@ -60,6 +74,7 @@ spec:
   - amd64
   - arm64
 options:
+  apiTimeout: 0
   dependencies:
   - name: olares
     type: system
@@ -72,3 +87,4 @@ entrances:
   icon: https://app.cdn.olares.com/appstore/radicale/icon.png
 permission:
   appCache: true
+  appData: true

--- a/radicale/i18n/en-US/OlaresManifest.yaml
+++ b/radicale/i18n/en-US/OlaresManifest.yaml
@@ -20,6 +20,20 @@ spec:
     - Can be extended with plugins.
     - Is GPLv3-licensed free software.
   upgradeDescription: |
+    v1.0.7 (Radicale 3.1.1 → 3.7.3)
+    - New: collection sharing via map or token, including management API and WebUI extension
+    - New: share an address book as a birthday calendar
+    - New: server option `delay_on_error` and logging option `limit_content`
+    - New: stricter `Content-Security-Policy` header by default on fresh configs
+    - New: `validate_user_value` / `validate_path_value` for safer filesystems
+    - Improved: WebUI refactor, smaller JS modules, better caching and error handling
+    - Improved: `path_to_filesystem()` performance and access-rights preload
+    - Improved: enforce `max_resource_size` on storage discover/get
+    - Fixed: MOVE with URL-encoded Destination header
+    - Fixed: sharing/PROPFIND/PROPPATCH permission checks and storage hook on delete
+    - Dependency: replaced unmaintained `passlib` with `libpass >= 1.9.3`, compatible with bcrypt 5.x
+
+    v1.0.6 (Radicale 3.1.x)
     - Fix setuptools requirement if installing wheel
-    - Tests: Switch from python setup.py test to tox
+    - Tests: switch from `python setup.py test` to tox
     - Small changes to build system configuration and tests

--- a/radicale/i18n/zh-CN/OlaresManifest.yaml
+++ b/radicale/i18n/zh-CN/OlaresManifest.yaml
@@ -20,6 +20,20 @@ spec:
     - 是基于GPLv3许可的自由软件。
 
   upgradeDescription: |
-    - 修复了安装wheel时的setuptools依赖要求
-    - 测试：从python setup.py test切换到tox
+    v1.0.7（Radicale 3.1.1 → 3.7.3）
+    - 新增：通过映射或令牌共享集合（Collection），并提供管理 API 和 WebUI 扩展
+    - 新增：将通讯录作为生日日历共享
+    - 新增：服务端选项 `delay_on_error`，日志选项 `limit_content`
+    - 新增：新配置默认启用更严格的 `Content-Security-Policy` 响应头
+    - 新增：`validate_user_value` / `validate_path_value`，用于在非 Unicode 文件系统上提高安全性
+    - 优化：WebUI 重构，拆分为更小的 JS 模块，缓存与错误处理统一
+    - 优化：`path_to_filesystem()` 性能与访问权限预加载
+    - 优化：在存储 discover/get 路径上强制校验 `max_resource_size`
+    - 修复：MOVE 请求中带 URL 编码的 Destination Header
+    - 修复：共享/PROPFIND/PROPPATCH 的权限检查，以及删除时的存储 Hook 触发
+    - 依赖：将停止维护的 `passlib` 替换为 `libpass >= 1.9.3`，兼容 bcrypt 5.x
+
+    v1.0.6（Radicale 3.1.x）
+    - 修复了安装 wheel 时的 setuptools 依赖要求
+    - 测试：从 `python setup.py test` 切换到 tox
     - 对构建系统配置和测试进行了小幅修改

--- a/radicale/owners
+++ b/radicale/owners
@@ -5,3 +5,4 @@ owners:
 - 'pengpeng'
 - 'harveyff'
 - 'zdf-org'
+- 'lovehunter9'

--- a/radicale/templates/all.yaml
+++ b/radicale/templates/all.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/instance: radicale
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: radicale
-    app.kubernetes.io/version: 3.1.1.0
-    helm.sh/chart: radicale-1.2.2
+    app.kubernetes.io/version: "3.7.3"
+    helm.sh/chart: radicale-1.0.7
   annotations:
 spec:
   type: ClusterIP
@@ -32,8 +32,8 @@ metadata:
     app.kubernetes.io/instance: radicale
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: radicale
-    app.kubernetes.io/version: 3.1.1.0
-    helm.sh/chart: radicale-1.2.2
+    app.kubernetes.io/version: "3.7.3"
+    helm.sh/chart: radicale-1.0.7
 spec:
   revisionHistoryLimit: 3
   replicas: 1
@@ -49,31 +49,53 @@ spec:
         app.kubernetes.io/name: radicale
         app.kubernetes.io/instance: radicale
     spec:
-      
       serviceAccountName: default
       automountServiceAccountToken: true
       dnsPolicy: ClusterFirst
       enableServiceLinks: true
+      securityContext:
+        fsGroup: 2999
+      initContainers:
+        - name: fix-permissions
+          image: "docker.io/beclab/aboveos-busybox:1.37.0"
+          command:
+            - sh
+            - "-c"
+          args:
+            - |
+              mkdir -p /data/collections
+              chown -R 2999:2999 /data
+              chmod -R 770 /data
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: radicale-data
+              mountPath: /data
       containers:
         - name: radicale
-          image: "docker.io/beclab/aboveos-tomsquest-docker-radicale:3.1.1.0"
+          image: "docker.io/beclab/tomsquest-docker-radicale:3.7.3.0"
           imagePullPolicy: IfNotPresent
           resources:
             requests:
-              cpu: 100m
-              memory: 64Mi
+              cpu: 250m
+              memory: 512Mi
             limits:
-              cpu: 500m
-              memory: 128Mi
+              cpu: 1000m
+              memory: 2Gi
           env:
             - name: RADICALE_CONFIG
               value: /config/config
             - name: TZ
               value: UTC
+            - name: TAKE_FILE_OWNERSHIP
+              value: "false"
           ports:
             - name: http
               containerPort: 5232
               protocol: TCP
+          volumeMounts:
+            - name: radicale-data
+              mountPath: /data
           livenessProbe:
             tcpSocket:
               port: 5232
@@ -95,3 +117,16 @@ spec:
             failureThreshold: 30
             timeoutSeconds: 1
             periodSeconds: 5
+      volumes:
+        - name: radicale-data
+          hostPath:
+            type: DirectoryOrCreate
+            {{- if .Values.sysVersion }}
+              {{- if semverCompare ">=1.12.3-0" (toString .Values.sysVersion) }}
+            path: '{{ .Values.userspace.appData }}'
+              {{- else }}
+            path: '{{ .Values.userspace.appData }}/radicale'
+              {{- end }}
+            {{- else }}
+            path: '{{ .Values.userspace.appData }}/radicale'
+            {{- end }}


### PR DESCRIPTION
### App Title
> Radicale

### Description
> - Upgrade to upstream Radicale v3.7.3
   - Persistent storage (survives restarts/reinstalls)
   - Higher default resources: RAM 512Mi/2Gi, CPU 250m/1000m
   - Drop the 15s route timeout for CalDAV PROPFIND / bulk import (an upstream ~5 min idle-stream timeout still applies to single requests)

### Statement
- [ ] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
