### PR TITLE
[UPDATE][speaches][1.0.13]

### DIFF
--- a/speaches/Chart.yaml
+++ b/speaches/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.12
+version: 1.0.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/speaches/OlaresManifest.yaml
+++ b/speaches/OlaresManifest.yaml
@@ -7,7 +7,7 @@ metadata:
   description: OpenAI-compatible TTS/STT server
   appid: speaches
   title: Speaches
-  version: '1.0.12'
+  version: '1.0.13'
   categories:
     - Utilities_v112
     - AI
@@ -88,21 +88,21 @@ spec:
   {{- $env := .Values.olaresEnv | default dict -}}
   {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
   {{- if ne (index $env "SPEACHES_GPU" | default "true") "false" }}
-  requiredMemory: 2.5Gi
-  limitedMemory: 9Gi
+  requiredMemory: 6.5Gi
+  limitedMemory: 20Gi
   requiredDisk: 2Gi
   limitedDisk: 20Gi
   requiredCpu: 0.6
-  limitedCpu: 9
-  requiredGpu: 4Gi
+  limitedCpu: 4.5
+  requiredGpu: 8Gi
   limitedGpu: 16Gi
   {{- else }}
-  requiredMemory: 2.5Gi
-  limitedMemory: 9Gi
+  requiredMemory: 4.5Gi
+  limitedMemory: 14Gi
   requiredDisk: 2Gi
   limitedDisk: 20Gi
   requiredCpu: 0.6
-  limitedCpu: 9
+  limitedCpu: 4.5
   {{- end }}
   {{- else }}
   requiredMemory: 64Mi
@@ -158,3 +158,10 @@ envs:
     editable: true
     default: "Systran/faster-whisper-small"
     description: "Whisper STT model for the whisper-1 alias. Default: Systran/faster-whisper-small (pre-installed). To use a larger model, download it via Terminal first, then set this to e.g. Systran/faster-whisper-large-v3."
+  - envName: CHAT_COMPLETION_BASE_URL
+    required: false
+    applyOnChange: true
+    type: string
+    editable: true
+    default: ""
+    description: "OpenAI-compatible LLM API base URL for the Audio Chat tab (must end with /v1). Leave empty to use the cluster default; set a custom URL to use your own LLM provider. Not needed for Speech-to-Text / Text-to-Speech."

--- a/speaches/speaches/Chart.yaml
+++ b/speaches/speaches/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "1.25.3-2"
 description: Speaches client proxy
 name: speaches
 type: application
-version: 1.0.12
+version: 1.0.13

--- a/speaches/speaches/templates/ingress.yaml
+++ b/speaches/speaches/templates/ingress.yaml
@@ -12,7 +12,7 @@ data:
       access_log /opt/bitnami/openresty/nginx/logs/access.log;
       error_log /opt/bitnami/openresty/nginx/logs/error.log;
 
-      client_max_body_size 50m;
+      client_max_body_size 500m;
 
       proxy_buffering off;
       proxy_redirect off;
@@ -41,7 +41,7 @@ data:
           proxy_connect_timeout 60s;
           proxy_read_timeout 600s;
           proxy_send_timeout 600s;
-          client_max_body_size 50m;
+          client_max_body_size 500m;
       }
     }
 
@@ -80,7 +80,7 @@ data:
       access_log /opt/bitnami/openresty/nginx/logs/access.log;
       error_log /opt/bitnami/openresty/nginx/logs/error.log;
 
-      client_max_body_size 50m;
+      client_max_body_size 500m;
 
       proxy_buffering off;
       proxy_redirect off;
@@ -109,7 +109,7 @@ data:
           proxy_connect_timeout 60s;
           proxy_read_timeout 600s;
           proxy_send_timeout 600s;
-          client_max_body_size 50m;
+          client_max_body_size 500m;
       }
     }
 

--- a/speaches/speachesserver/Chart.yaml
+++ b/speaches/speachesserver/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "0.8.2"
 description: Speaches server (shared)
 name: speachesserver
 type: application
-version: 1.0.12
+version: 1.0.13

--- a/speaches/speachesserver/templates/speaches.yaml
+++ b/speaches/speachesserver/templates/speaches.yaml
@@ -4,6 +4,8 @@
 {{- $speachesDomainENV := split "," .Values.domain.speaches -}}
 {{- $speachesDomain := index $speachesDomainENV "_0" -}}
 {{- $topDomain := regexReplaceAll ".*?([^.]+\\.[^.]+)$" $speachesDomain "$1" -}}
+{{- $defaultChatUrl := printf "http://d54536a50.shared.%s/v1" $topDomain -}}
+{{- $userChatUrl := index $env "CHAT_COMPLETION_BASE_URL" | default "" | trim -}}
 
 ---
 apiVersion: apps/v1
@@ -115,7 +117,7 @@ spec:
                   || echo "WARN: failed to install misaki[zh] - Chinese voices will fall back to espeak cmn"
               fi
               python3 << 'PATCH_EOF'
-              import pathlib, json, os
+              import pathlib, json, os, re
               patched = []
 
               # whisper-1 alias: configurable via SPEACHES_WHISPER_MODEL env var
@@ -154,6 +156,60 @@ spec:
               if s != o:
                   f.write_text(s)
                   patched.append('audio_chat.py')
+
+              # audio_chat.py: graceful models.list() for the LLM model dropdown.
+              # Regex body-replace (robust to upstream formatting: one-line vs multi-line
+              # AsyncOpenAI args, presence/absence of max_retries, the NOTE comment, etc.).
+              # On any failure (unreachable / bad URL / malformed /v1/models response) it
+              # returns a gray hint dropdown instead of raising a red error.
+              f = pathlib.Path('/home/ubuntu/speaches/src/speaches/ui/tabs/audio_chat.py')
+              s = f.read_text()
+              o = s
+              new_llm_fn = (
+                  '    async def update_chat_model_dropdown() -> gr.Dropdown:\n'
+                  '        import httpx\n'
+                  '        _hint = gr.Dropdown(\n'
+                  '            choices=[],\n'
+                  '            label="Chat Model",\n'
+                  '            value=None,\n'
+                  '            info="Could not load chat models. Check CHAT_COMPLETION_BASE_URL in the app environment variables (an OpenAI-compatible endpoint ending in /v1), then switch to another tab and back.",\n'
+                  '        )\n'
+                  '        try:\n'
+                  '            openai_client = AsyncOpenAI(\n'
+                  '                base_url=config.chat_completion_base_url,\n'
+                  '                api_key=config.chat_completion_api_key.get_secret_value(),\n'
+                  '                max_retries=0,\n'
+                  '                timeout=httpx.Timeout(10.0),\n'
+                  '            )\n'
+                  '            models = (await openai_client.models.list()).data\n'
+                  '            model_ids: list[str] = [model.id for model in models]\n'
+                  '        except Exception:\n'
+                  '            logger.exception("Audio Chat: failed to load LLM models (url=%s)", config.chat_completion_base_url)\n'
+                  '            return _hint\n'
+                  '        if not model_ids:\n'
+                  '            return gr.Dropdown(\n'
+                  '                choices=[],\n'
+                  '                label="Chat Model",\n'
+                  '                value=None,\n'
+                  '                info="The LLM endpoint is reachable but returned no models. Make sure at least one model is available, then switch to another tab and back.",\n'
+                  '            )\n'
+                  '        return gr.Dropdown(\n'
+                  '            choices=model_ids,\n'
+                  '            label="Chat Model",\n'
+                  '            value=model_ids[0],\n'
+                  '        )'
+              )
+              _llm_pat = re.compile(
+                  r'    async def update_chat_model_dropdown\(\) -> gr\.Dropdown:.*?(?=\n+    with gr\.Tab\(label="Audio Chat"\))',
+                  re.DOTALL,
+              )
+              if _llm_pat.search(s):
+                  s = _llm_pat.sub(lambda _m: new_llm_fn, s, count=1)
+              else:
+                  print('WARN: update_chat_model_dropdown not found - LLM dropdown NOT patched', flush=True)
+              if s != o:
+                  f.write_text(s)
+                  patched.append('audio_chat.py (LLM dropdown error handling)')
 
               # Write mic-fix JS (delays submit click while mic upload is pending)
               mic_fix_head = (
@@ -323,25 +379,29 @@ spec:
             - name: LOOPBACK_HOST_URL
               value: "http://localhost:8000"
             - name: CHAT_COMPLETION_BASE_URL
-              value: "http://d54536a50.shared.{{ $topDomain }}/v1"
+              {{- if $userChatUrl }}
+              value: {{ $userChatUrl | quote }}
+              {{- else }}
+              value: {{ $defaultChatUrl | quote }}
+              {{- end }}
           ports:
             - containerPort: 8000
               protocol: TCP
           resources:
             {{- if $speachesGpu }}
             limits:
-              cpu: "8"
-              memory: 8Gi
+              cpu: "4"
+              memory: 18Gi
             requests:
               cpu: 500m
-              memory: 2Gi
+              memory: 6Gi
             {{- else }}
             limits:
-              cpu: "8"
-              memory: 8Gi
+              cpu: "4"
+              memory: 12Gi
             requests:
               cpu: 500m
-              memory: 2Gi
+              memory: 4Gi
             {{- end }}
           volumeMounts:
             - name: speaches-hf-cache


### PR DESCRIPTION
### App Title
> Speaches

### Description
> Increased resource requests and limits to prevent out-of-memory issues when processing long audio with large models.
   Added a graceful fallback notice on the Audio Chat page for when the chat model service is unreachable or the model list cannot be fetched on page load (avoiding a hard error that hurts the user experience).
   Added the environment variable CHAT_COMPLETION_BASE_URL to let users configure their own chat model endpoint, defaulting to the ollamav2 address used in previous versions when left empty.

### Statement
- [ ] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
