### PR TITLE
[UPDATE][sglangllmbasev3][1.0.1] start --model-path from MODEL_NAME

### DIFF
--- a/sglangllmbasev3/Chart.yaml
+++ b/sglangllmbasev3/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.5.12.post1
 description: Generic SGLang + llm-init base; the model is supplied at install time via env
 name: sglangllmbasev3
 type: application
-version: 1.0.0
+version: 1.0.1

--- a/sglangllmbasev3/OlaresManifest.yaml
+++ b/sglangllmbasev3/OlaresManifest.yaml
@@ -7,7 +7,7 @@ metadata:
   description: "Generic SGLang + llm-init base. Pick any HF model at install via env."
   appid: sglangllmbasev3
   title: SGLang LLM Base (llm-init)
-  version: '1.0.0'
+  version: '1.0.1'
   categories:
     - AI
 sharedEntrances:
@@ -40,10 +40,11 @@ spec:
 
     **HOW IT WORKS**
     The llm-init sidecar downloads the configured HF model, writes a readiness
-    sentinel + model path, and exposes an OpenAI-compatible `/v1/*` surface plus
-    a unified `/api/progress` + `/healthz` dashboard. The SGLang container waits
-    for the sentinel, then serves the model. llm-init and SGLang run in separate
-    Deployments and share the HF cache + run-state via hostPath.
+    sentinel, and exposes an OpenAI-compatible `/v1/*` surface plus a unified
+    `/api/progress` + `/healthz` dashboard. The SGLang container waits for the
+    sentinel, then loads `--model-path` from `MODEL_NAME` (HF `owner/repo`, same
+    repo as `MODEL_SOURCE`). llm-init and SGLang run in separate Deployments and
+    share the HF cache + run-state via hostPath.
 
     **Stack**
     - **SGLang** (`lmsysorg/sglang`, port 30000): GPU inference, OpenAI server.
@@ -56,7 +57,8 @@ spec:
 
     **Install-time parameters (set per model)**
     - `MODEL_SOURCE` — `hf://<repo>` (optionally `--include <file>` / `--revision <sha>`).
-    - `MODEL_NAME` — OpenAI client alias + SGLang `--served-model-name`.
+    - `MODEL_NAME` — HF `owner/repo` for SGLang `--model-path` and `--served-model-name`
+      (must match the repo in `MODEL_SOURCE`, e.g. `Qwen/Qwen3-0.6B`).
     - `MODEL_MODE` — `chat` or `embedding`.
     - `MODEL_SUPPORTS` — CSV of `supports_*` capability keys (empty if none).
     - `ENGINE_ARGS` — SGLang CLI flags, e.g. `--context-length 8192 --mem-fraction-static 0.8 --tp 1`.
@@ -119,7 +121,7 @@ envs:
     type: string
     editable: true
     applyOnChange: true
-  - envName: MODEL_NAME          # example: qwen3-0.6b
+  - envName: MODEL_NAME          # example: Qwen/Qwen3-0.6B  (--model-path owner/repo)
     required: true
     type: string
     editable: true

--- a/sglangllmbasev3/i18n/en-US/OlaresManifest.yaml
+++ b/sglangllmbasev3/i18n/en-US/OlaresManifest.yaml
@@ -17,6 +17,6 @@ spec:
 
     **Install-time parameters**
     - `MODEL_SOURCE` — `hf://<repo>` (`--include` / `--revision` optional).
-    - `MODEL_NAME` — OpenAI alias + `--served-model-name`.
+    - `MODEL_NAME` — HF `owner/repo` for `--model-path` + `--served-model-name`.
     - `ENGINE_ARGS` — SGLang flags, e.g. `--context-length 8192 --mem-fraction-static 0.8`.
     - `SGLANG_CPU_*` / `SGLANG_MEMORY_*` — engine pod resources.

--- a/sglangllmbasev3/i18n/zh-CN/OlaresManifest.yaml
+++ b/sglangllmbasev3/i18n/zh-CN/OlaresManifest.yaml
@@ -16,6 +16,6 @@ spec:
 
     **安装时参数**
     - `MODEL_SOURCE` —— `hf://<repo>`（`--include` / `--revision` 可选）。
-    - `MODEL_NAME` —— OpenAI 别名 + `--served-model-name`。
+    - `MODEL_NAME` —— HF `owner/repo`，用于 `--model-path` 与 `--served-model-name`。
     - `ENGINE_ARGS` —— SGLang 参数，如 `--context-length 8192 --mem-fraction-static 0.8`。
     - `SGLANG_CPU_*` / `SGLANG_MEMORY_*` —— 引擎 Pod 资源。

--- a/sglangllmbasev3/templates/llm-init.yaml
+++ b/sglangllmbasev3/templates/llm-init.yaml
@@ -15,7 +15,7 @@
 {{- $hfToken := $oe.HF_TOKEN | default "" -}}
 {{- $runStateHostPath := printf "%s/llm-init-run/%s" .Values.userspace.appCache .Release.Name -}}
 ---
-# llm-init Pod (no GPU). Downloads HF models, writes sentinel + model_path,
+# llm-init Pod (no GPU). Downloads HF models, writes the readiness sentinel,
 # serves progress UI + OpenAI /v1/* proxy on :8090, reverse-proxies the engine
 # at http://sglang:30000 (llm-init v1.1.0 derives URL from ENGINE_KIND).
 apiVersion: apps/v1

--- a/sglangllmbasev3/templates/sglang.yaml
+++ b/sglangllmbasev3/templates/sglang.yaml
@@ -8,8 +8,8 @@
 {{- $runStateHostPath := printf "%s/llm-init-run/%s" .Values.userspace.appCache .Release.Name -}}
 ---
 # SGLang engine Deployment (GPU). wrappers/sglang.sh blocks on the sentinel
-# llm-init writes, reads model_path, then execs launch_server on :30000.
-# llm-init reverse-proxies at http://sglang:30000 — Service name MUST be "sglang".
+# llm-init writes, then execs launch_server with --model-path "$MODEL_NAME" on
+# :30000. llm-init reverse-proxies at http://sglang:30000 — Service name MUST be "sglang".
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/sglangllmbasev3/templates/wrappers.yaml
+++ b/sglangllmbasev3/templates/wrappers.yaml
@@ -3,9 +3,9 @@
 # deploy/wrappers/{common.sh,sglang.sh} are inlined (this chart runs one engine).
 #
 # SGLang's deployment model: llm-init downloads the HF model into the shared
-# /cache/hf/hub cache and writes a readiness sentinel + model_path under
-# /run/llm-init; the engine waits on the sentinel and loads --model-path from
-# the resolved snapshot path.
+# /cache/hf/hub cache and writes a readiness sentinel under /run/llm-init; the
+# engine waits on the sentinel and loads --model-path from MODEL_NAME (the HF
+# owner/repo id), resolving against the shared cache.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -19,9 +19,9 @@ data:
     # SGLang engine wrapper (single file; helpers inlined from llm-init v1.1.0
     # common.sh + sglang.sh).
     #
-    # Waits for llm-init to publish the sentinel + model_path files, then
-    # launches SGLang's OpenAI-compatible server with --model-path pointed at
-    # the path llm-init wrote.
+    # Waits for llm-init to publish the sentinel, then launches SGLang's
+    # OpenAI-compatible server with --model-path set to MODEL_NAME (HF
+    # owner/repo); SGLang resolves it against the shared /cache/hf/hub cache.
     #
     # v1.1.0 ENGINE_ARGS contract (docs/engine-args.md): a cmdline-style string
     # in SGLang's native flag syntax. Shell-word-split and appended after the
@@ -34,10 +34,26 @@ data:
 
     ENGINE=sglang
     SENTINEL=${SENTINEL:-/run/llm-init/model_download_finish}
-    MODEL_PATH_FILE=${MODEL_PATH_FILE:-/run/llm-init/model_path}
     WAIT_INTERVAL=${WAIT_INTERVAL:-5}
     WAIT_TIMEOUT=${WAIT_TIMEOUT:-3600}
     log() { printf '[wrapper-%s] %s\n' "$ENGINE" "$*"; }
+
+    looks_like_hf_repo_id() {
+        s=$1
+        case "$s" in
+            ""|/*|./*|*://*) return 1 ;;
+        esac
+        case "$s" in
+            */*)
+                rest=${s#*/}
+                case "$rest" in
+                    */*|*:*) return 1 ;;
+                esac
+                return 0
+                ;;
+            *) return 1 ;;
+        esac
+    }
 
     elapsed=0
     while [ ! -f "$SENTINEL" ]; do
@@ -51,14 +67,16 @@ data:
     done
     log "sentinel $SENTINEL found after ${elapsed}s"
 
-    [ -f "$MODEL_PATH_FILE" ] || { log "model path file $MODEL_PATH_FILE not found"; exit 1; }
-    MODEL_PATH=$(tr -d '\r\n' < "$MODEL_PATH_FILE")
-    log "starting SGLang with model-path=$MODEL_PATH name=${MODEL_NAME:-unset} args=${ENGINE_ARGS:-<empty>}"
+    if ! looks_like_hf_repo_id "${MODEL_NAME:-}"; then
+        log "MODEL_NAME must be owner/repo for --model-path (got ${MODEL_NAME:-<empty>})"
+        exit 1
+    fi
+    log "starting SGLang with model-path=$MODEL_NAME args=${ENGINE_ARGS:-<empty>}"
 
     # shellcheck disable=SC2086  # intentional word-splitting of ENGINE_ARGS
     exec python3 -m sglang.launch_server \
-        --model-path "$MODEL_PATH" \
-        --served-model-name "${MODEL_NAME:-llm-init-model}" \
+        --model-path "$MODEL_NAME" \
+        --served-model-name "$MODEL_NAME" \
         --host 0.0.0.0 \
         --port "${SGLANG_PORT:-30000}" \
         --enable-metrics \


### PR DESCRIPTION
- Wrapper waits on sentinel then serves --model-path "$MODEL_NAME" (HF owner/repo) instead of reading model_path; validates repo id format
- Update docs/i18n for new MODEL_NAME semantics

### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
> The title of your application appears on Market.

### Description
> Brief description about your application here. 
>
> For app updates, please describe the changes.

### Statement
- [ ] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
