### PR TITLE
[UPDATE][vllmllmbasev3][1.0.4] HF cache env, MODEL_NAME boot, llm-init v1.2.3 1Gi

### DIFF
--- a/vllmllmbasev3/Chart.yaml
+++ b/vllmllmbasev3/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.22.0
 description: Generic vLLM + llm-init base; the model is supplied at install time via env
 name: vllmllmbasev3
 type: application
-version: 1.0.2
+version: 1.0.4

--- a/vllmllmbasev3/OlaresManifest.yaml
+++ b/vllmllmbasev3/OlaresManifest.yaml
@@ -7,7 +7,7 @@ metadata:
   description: "Generic vLLM + llm-init base. Pick any HF model at install via env."
   appid: vllmllmbasev3
   title: vLLM LLM Base (llm-init)
-  version: '1.0.2'
+  version: '1.0.4'
   categories:
     - AI
 sharedEntrances:
@@ -97,12 +97,13 @@ spec:
       `required*`/`limited*` on clone.
 
   upgradeDescription: |
-    Generic vLLM + llm-init base (llm-init v1.1.0, vllm/vllm-openai:v0.22.0).
+    Generic vLLM + llm-init base (llm-init v1.2.3, vllm/vllm-openai:v0.22.0).
     Loads any HF model; model identity, source and tuning are install-time env.
     Models live in the shared cross-app App Common store appCommon/huggingface.
     v1.0.16: sentinel/model_path now live under appCache/llm-init-run/<instance>
     per release (fixes cross-instance handshake collisions). After upgrade, Retry
     once or restart both workloads so vLLM picks up the new model_path.
+    v1.0.4: bump llm-init to v1.2.3, raise memory limit to 1Gi, pin HF cache env on engine.
 
   developer: beclab
   website: https://github.com/beclab/llm-init

--- a/vllmllmbasev3/i18n/en-US/OlaresManifest.yaml
+++ b/vllmllmbasev3/i18n/en-US/OlaresManifest.yaml
@@ -47,6 +47,6 @@ spec:
     `requiredCpu` on clone when `VLLM_*_REQUEST` exceeds the floor.
 
   upgradeDescription: |
-    Generic vLLM + llm-init base (llm-init v1.1.0, vllm/vllm-openai:v0.22.0).
+    Generic vLLM + llm-init base (llm-init v1.2.3, vllm/vllm-openai:v0.22.0).
     Loads any HF model; model identity, source and tuning are install-time env.
     Models live in the shared cross-app App Common store appCommon/huggingface.

--- a/vllmllmbasev3/i18n/zh-CN/OlaresManifest.yaml
+++ b/vllmllmbasev3/i18n/zh-CN/OlaresManifest.yaml
@@ -43,6 +43,6 @@ spec:
     / `requiredCpu`。
 
   upgradeDescription: |
-    通用 vLLM + llm-init 基座（llm-init v1.1.0，vllm/vllm-openai:v0.22.0）。
+    通用 vLLM + llm-init 基座（llm-init v1.2.3，vllm/vllm-openai:v0.22.0）。
     加载任意 HF 模型；模型身份、来源与调参均为安装时环境变量。
     模型存于跨应用共享的 App Common 目录 appCommon/huggingface。

--- a/vllmllmbasev3/templates/llm-init.yaml
+++ b/vllmllmbasev3/templates/llm-init.yaml
@@ -74,7 +74,7 @@ spec:
               mountPath: /run/llm-init
       containers:
         - name: llm-init
-          image: docker.io/beclab/llm-init:v1.1.0
+          image: docker.io/beclab/llm-init:v1.2.3
           imagePullPolicy: IfNotPresent
           env:
             - name: ENGINE_KIND
@@ -138,8 +138,10 @@ spec:
               cpu: 100m
               memory: 128Mi
             limits:
+              # hf download (4 workers) needs headroom; 256Mi gets OOMKilled
+              # mid-download -> pod restart -> state machine wedges. 1Gi is safe.
               cpu: 500m
-              memory: 256Mi
+              memory: 1Gi
 ---
 # llm-init download/progress + OpenAI proxy surface (app entrance backend).
 apiVersion: v1

--- a/vllmllmbasev3/templates/vllm.yaml
+++ b/vllmllmbasev3/templates/vllm.yaml
@@ -3,6 +3,8 @@
 {{- $oe := .Values.olaresEnv | default dict -}}
 {{- $modelName := $oe.MODEL_NAME | default "" -}}
 {{- $engineArgs := $oe.ENGINE_ARGS | default "" -}}
+{{- $hfEndpoint := $oe.HF_ENDPOINT | default "" -}}
+{{- $hfToken := $oe.HF_TOKEN | default "" -}}
 {{- /* Defaults avoid empty K8s quantities. CPU needs "m" (200m = 0.2 core).
        Sums (llm-init + vllm) must fit the manifest accelerator limits. */ -}}
 {{- $cpuRequest := trim ($oe.VLLM_CPU_REQUEST | default "200m") -}}
@@ -16,7 +18,8 @@
 # the shared run-state dir, then serves --model "$MODEL_NAME" on :8000. llm-init
 # reverse-proxies http://vllm:8000 via the "vllm" Service below.
 # Shared hostPath volumes (read-only here, llm-init owns writes): hf-cache
-# (/cache/hf/hub), run-state (sentinel handshake).
+# (/cache/hf/hub). Engine env pins HF_HUB_CACHE/HF_HOME and HF_HUB_OFFLINE so
+# --model "$MODEL_NAME" resolves the llm-init cache without Hub writes.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -69,6 +72,20 @@ spec:
               value: "3600"
             - name: ENGINE_ARGS
               value: "{{ $engineArgs }}"
+            - name: HF_HUB_CACHE
+              value: /cache/hf/hub
+            - name: HF_HOME
+              value: /cache/hf
+            - name: HF_HUB_OFFLINE
+              value: "1"
+{{- if $hfEndpoint }}
+            - name: HF_ENDPOINT
+              value: "{{ $hfEndpoint }}"
+{{- end }}
+{{- if $hfToken }}
+            - name: HF_TOKEN
+              value: "{{ $hfToken }}"
+{{- end }}
             - name: PYTHONUNBUFFERED
               value: "1"
             - name: PGID


### PR DESCRIPTION
## Summary
- Pin HF_HUB_CACHE / HF_HOME / HF_HUB_OFFLINE on vLLM engine for read-only shared cache
- Start engine with MODEL_NAME (`--model owner/repo`) instead of sentinel model_path
- Bump llm-init to beclab/llm-init:v1.2.3 and raise memory limit to 1Gi

## Test plan
- [ ] Install with MODEL_SOURCE=hf://Qwen/Qwen3-0.6B + MODEL_NAME=Qwen/Qwen3-0.6B
- [ ] Confirm llm-init completes download without OOM restart
- [ ] Confirm vLLM serves /v1/models after ready

Made with [Cursor](https://cursor.com)