### PR TITLE
[UPDATE][sglangllmbasev3][1.0.2] HF cache env, MODEL_NAME boot, llm-init v1.2.3

### DIFF
--- a/sglangllmbasev3/Chart.yaml
+++ b/sglangllmbasev3/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.5.12.post1
 description: Generic SGLang + llm-init base; the model is supplied at install time via env
 name: sglangllmbasev3
 type: application
-version: 1.0.1
+version: 1.0.2

--- a/sglangllmbasev3/OlaresManifest.yaml
+++ b/sglangllmbasev3/OlaresManifest.yaml
@@ -7,7 +7,7 @@ metadata:
   description: "Generic SGLang + llm-init base. Pick any HF model at install via env."
   appid: sglangllmbasev3
   title: SGLang LLM Base (llm-init)
-  version: '1.0.1'
+  version: '1.0.2'
   categories:
     - AI
 sharedEntrances:
@@ -73,7 +73,7 @@ spec:
       `SGLANG_MEMORY_*`). Olares validates sums across llm-init + sglang containers.
 
   upgradeDescription: |
-    Generic SGLang + llm-init base (llm-init v1.2.1, lmsysorg/sglang:v0.5.12.post1-cu130).
+    Generic SGLang + llm-init base (llm-init v1.2.3, lmsysorg/sglang:v0.5.12.post1-cu130).
     Loads any HF model; model identity, source and tuning are install-time env.
     Models live in the shared App Common store appCommon/huggingface.
     Sentinel/model_path are per-instance under appCache/llm-init-run/<release>.

--- a/sglangllmbasev3/templates/llm-init.yaml
+++ b/sglangllmbasev3/templates/llm-init.yaml
@@ -62,7 +62,7 @@ spec:
               mountPath: /run/llm-init
       containers:
         - name: llm-init
-          image: docker.io/beclab/llm-init:v1.2.1
+          image: docker.io/beclab/llm-init:v1.2.3
           imagePullPolicy: IfNotPresent
           env:
             - name: ENGINE_KIND

--- a/sglangllmbasev3/templates/sglang.yaml
+++ b/sglangllmbasev3/templates/sglang.yaml
@@ -1,6 +1,8 @@
 {{- $oe := .Values.olaresEnv | default dict -}}
 {{- $modelName := $oe.MODEL_NAME | default "" -}}
 {{- $engineArgs := $oe.ENGINE_ARGS | default "" -}}
+{{- $hfEndpoint := $oe.HF_ENDPOINT | default "" -}}
+{{- $hfToken := $oe.HF_TOKEN | default "" -}}
 {{- $cpuRequest := trim ($oe.SGLANG_CPU_REQUEST | default "200m") -}}
 {{- $memRequest := trim ($oe.SGLANG_MEMORY_REQUEST | default "2Gi") -}}
 {{- $cpuLimit := trim ($oe.SGLANG_CPU_LIMIT | default "6") -}}
@@ -9,7 +11,8 @@
 ---
 # SGLang engine Deployment (GPU). wrappers/sglang.sh blocks on the sentinel
 # llm-init writes, then execs launch_server with --model-path "$MODEL_NAME" on
-# :30000. llm-init reverse-proxies at http://sglang:30000 — Service name MUST be "sglang".
+# :30000. Engine env pins HF_HUB_CACHE/HF_HOME and HF_HUB_OFFLINE so repo id
+# resolves llm-init's read-only shared cache without Hub metadata writes.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -62,6 +65,20 @@ spec:
               value: "3600"
             - name: ENGINE_ARGS
               value: "{{ $engineArgs }}"
+            - name: HF_HUB_CACHE
+              value: /cache/hf/hub
+            - name: HF_HOME
+              value: /cache/hf
+            - name: HF_HUB_OFFLINE
+              value: "1"
+{{- if $hfEndpoint }}
+            - name: HF_ENDPOINT
+              value: "{{ $hfEndpoint }}"
+{{- end }}
+{{- if $hfToken }}
+            - name: HF_TOKEN
+              value: "{{ $hfToken }}"
+{{- end }}
             - name: PYTHONUNBUFFERED
               value: "1"
             - name: PGID


### PR DESCRIPTION
## Summary
- Pin HF_HUB_CACHE / HF_HOME / HF_HUB_OFFLINE on SGLang engine for read-only shared cache
- Start engine with MODEL_NAME as `--model-path` / `--served-model-name`
- Bump llm-init to beclab/llm-init:v1.2.3 (memory limit already 1Gi)

## Test plan
- [ ] Install with MODEL_SOURCE=hf://Qwen/Qwen3-0.6B + MODEL_NAME=Qwen/Qwen3-0.6B
- [ ] Confirm download completes and SGLang serves inference

Made with [Cursor](https://cursor.com)