### PR TITLE
[UPDATE][llamacppllmbasev3][1.0.1] HF cache env, llm-init v1.2.3

### DIFF
--- a/llamacppllmbasev3/Chart.yaml
+++ b/llamacppllmbasev3/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: b9426
 description: Generic llama.cpp + llm-init base; the GGUF model is supplied at install time via env
 name: llamacppllmbasev3
 type: application
-version: 1.0.0
+version: 1.0.1

--- a/llamacppllmbasev3/OlaresManifest.yaml
+++ b/llamacppllmbasev3/OlaresManifest.yaml
@@ -7,7 +7,7 @@ metadata:
   description: "Generic llama.cpp + llm-init base. Pick any GGUF model at install via env."
   appid: llamacppllmbasev3
   title: llama.cpp LLM Base (llm-init)
-  version: '1.0.0'
+  version: '1.0.1'
   categories:
     - AI
 sharedEntrances:
@@ -78,7 +78,7 @@ spec:
       `LLAMACPP_MEMORY_*`). Olares validates sums across llm-init + llamacpp.
 
   upgradeDescription: |
-    Generic llama.cpp + llm-init base (llm-init v1.2.1, beclab/ggml-org-llama.cpp:server-cuda12-b9426).
+    Generic llama.cpp + llm-init base (llm-init v1.2.3, beclab/ggml-org-llama.cpp:server-cuda12-b9426).
     Loads any GGUF model; model identity, source and tuning are install-time env.
     Models live in the shared App Common store appCommon/huggingface.
     Sentinel/model_path are per-instance under appCache/llm-init-run/<release>.

--- a/llamacppllmbasev3/README.md
+++ b/llamacppllmbasev3/README.md
@@ -4,7 +4,7 @@
 但引擎换成 llama.cpp、模型格式换成 **GGUF**。
 
 - **引擎镜像**: `beclab/ggml-org-llama.cpp:server-cuda12-b9426`（GPU / CUDA 12）
-- **llm-init**: `beclab/llm-init:v1.2.1`
+- **llm-init**: `beclab/llm-init:v1.2.3`
 - **版本**: chart `1.0.0` / appVersion `b9426`
 
 ## 架构

--- a/llamacppllmbasev3/templates/llamacpp.yaml
+++ b/llamacppllmbasev3/templates/llamacpp.yaml
@@ -10,10 +10,8 @@
 {{- $runStateHostPath := printf "%s/llm-init-run/%s" .Values.userspace.appCache .Release.Name -}}
 ---
 # llama.cpp engine Deployment. wrappers/llamacpp.sh blocks on the sentinel
-# (download ready), then execs llama-server -hf "$MODEL_NAME".
-# llm-init reverse-proxies at http://llamacpp:8081 — Service name MUST be
-# "llamacpp". GPU base: CUDA server build + gpu-inject; put `-ngl all` in
-# ENGINE_ARGS to offload all layers to the GPU.
+# (download ready), then execs llama-server -hf "$MODEL_NAME". HF_HUB_CACHE/
+# HF_HOME/HF_HUB_OFFLINE pin the read-only shared cache llm-init populated.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -68,6 +66,10 @@ spec:
               value: "{{ $engineArgs }}"
             - name: HF_HUB_CACHE
               value: /cache/hf/hub
+            - name: HF_HOME
+              value: /cache/hf
+            - name: HF_HUB_OFFLINE
+              value: "1"
 {{- if $hfEndpoint }}
             - name: HF_ENDPOINT
               value: "{{ $hfEndpoint }}"

--- a/llamacppllmbasev3/templates/llm-init.yaml
+++ b/llamacppllmbasev3/templates/llm-init.yaml
@@ -63,7 +63,7 @@ spec:
               mountPath: /run/llm-init
       containers:
         - name: llm-init
-          image: docker.io/harveyff/llm-init:v1.2.1-fix4-amd
+          image: docker.io/beclab/llm-init:v1.2.3
           imagePullPolicy: IfNotPresent
           env:
             - name: ENGINE_KIND


### PR DESCRIPTION
## Summary
- Pin HF_HUB_CACHE / HF_HOME / HF_HUB_OFFLINE on llama.cpp engine for read-only shared cache
- Switch llm-init from harveyff fork to beclab/llm-init:v1.2.3
- llm-init memory limit already 1Gi for HF download headroom

## Test plan
- [ ] Install with GGUF MODEL_SOURCE + MODEL_NAME + ENGINE_ARGS=-ngl all
- [ ] Confirm download and llama-server serves on :8081

Made with [Cursor](https://cursor.com)