### PR TITLE
[UPDATE][ollamav2][1.1.1]update image to ollama/ollama:0.30.6 and ref…

### DIFF
--- a/ollamav2/Chart.yaml
+++ b/ollamav2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: '0.30.0'
+appVersion: '0.30.6'
 description: description
 name: ollamav2
 type: application
-version: 1.1.0
+version: 1.1.1

--- a/ollamav2/OlaresManifest.yaml
+++ b/ollamav2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: Get up and running with large language models.
   appid: ollamav2
   title: Ollama
-  version: "1.1.0"
+  version: "1.1.1"
   categories:
     - Utilities_v112
     - Productivity
@@ -37,7 +37,7 @@ entrances:
     invisible: true
 
 spec:
-  versionName: "0.30.0"
+  versionName: "0.30.6"
   featuredImage: https://app.cdn.olares.com/appstore/ollama/1.webp
   promoteImage:
     - https://app.cdn.olares.com/appstore/ollama/1.webp
@@ -68,9 +68,20 @@ spec:
     - Solar 10.7B
 
   upgradeDescription: |
-    Upgrade Ollama from v0.24.0 to v0.30.0
+    Upgrade Ollama from v0.30.0 to v0.30.6
 
     **What's Changed**
+
+    v0.30.6 (2026-06-05)
+    - New models: Gemma 4 QAT (Quantization-Aware Training) weights that dramatically cut memory use and boost on-device performance — tags ending in `-qat` (e.g. `gemma4:e2b-it-qat`, `gemma4:12b-it-qat`, `gemma4:31b-it-qat`)
+    - `ollama launch omp` now integrates with Oh My Pi, an AI coding agent with IDE integration
+    - MLX embedding layers now use NVFP4 global scale for improved quantization on Apple Silicon
+
+    v0.30.5 (2026-06-04)
+    - Fixed the `gemma4:12b` floating point exception crash on x86, CUDA, Linux, and Windows
+    - `ollama launch hermes-desktop` now skips rebuilding when a packaged desktop app is already installed
+    - `ollama launch hermes` now supports native Windows installs through the Hermes PowerShell installer
+    - Added Cline CLI integration docs
 
     v0.30.0 (2026-05-13)
     - Ollama 0.30 improves compatibility and performance using llama.cpp, augmenting the MLX engine on Apple Silicon for broader hardware support

--- a/ollamav2/i18n/en-US/OlaresManifest.yaml
+++ b/ollamav2/i18n/en-US/OlaresManifest.yaml
@@ -27,9 +27,20 @@ spec:
     - Solar 10.7B
 
   upgradeDescription: |
-    Upgrade Ollama from v0.24.0 to v0.30.0
+    Upgrade Ollama from v0.30.0 to v0.30.6
 
     **What's Changed**
+
+    v0.30.6 (2026-06-05)
+    - New models: Gemma 4 QAT (Quantization-Aware Training) weights that dramatically cut memory use and boost on-device performance — tags ending in `-qat` (e.g. `gemma4:e2b-it-qat`, `gemma4:12b-it-qat`, `gemma4:31b-it-qat`)
+    - `ollama launch omp` now integrates with Oh My Pi, an AI coding agent with IDE integration
+    - MLX embedding layers now use NVFP4 global scale for improved quantization on Apple Silicon
+
+    v0.30.5 (2026-06-04)
+    - Fixed the `gemma4:12b` floating point exception crash on x86, CUDA, Linux, and Windows
+    - `ollama launch hermes-desktop` now skips rebuilding when a packaged desktop app is already installed
+    - `ollama launch hermes` now supports native Windows installs through the Hermes PowerShell installer
+    - Added Cline CLI integration docs
 
     v0.30.0 (2026-05-13)
     - Ollama 0.30 improves compatibility and performance using llama.cpp, augmenting the MLX engine on Apple Silicon for broader hardware support

--- a/ollamav2/i18n/zh-CN/OlaresManifest.yaml
+++ b/ollamav2/i18n/zh-CN/OlaresManifest.yaml
@@ -29,9 +29,20 @@ spec:
     - Solar 10.7B
 
   upgradeDescription: |
-    将 Ollama 从 v0.24.0 升级至 v0.30.0
+    将 Ollama 从 v0.30.0 升级至 v0.30.6
 
     **更新内容**
+
+    v0.30.6 (2026-06-05)
+    - 新增模型：Gemma 4 QAT（量化感知训练）权重，大幅降低显存占用并提升端侧性能——标签以 `-qat` 结尾（如 `gemma4:e2b-it-qat`、`gemma4:12b-it-qat`、`gemma4:31b-it-qat`）
+    - `ollama launch omp` 现已集成 Oh My Pi（带 IDE 集成的 AI 编码助手）
+    - MLX 嵌入层改用 NVFP4 全局缩放，提升 Apple Silicon 上的量化质量
+
+    v0.30.5 (2026-06-04)
+    - 修复 `gemma4:12b` 在 x86、CUDA、Linux 与 Windows 上的浮点异常崩溃
+    - `ollama launch hermes-desktop` 在已安装打包桌面应用时不再重复构建
+    - `ollama launch hermes` 现支持通过 Hermes PowerShell 安装器进行原生 Windows 安装
+    - 新增 Cline CLI 集成文档
 
     v0.30.0 (2026-05-13)
     - Ollama 0.30 基于 llama.cpp 提升兼容性与性能，并在 Apple Silicon 上增强 MLX 引擎，覆盖更广的硬件

--- a/ollamav2/ollamaserver/Chart.yaml
+++ b/ollamav2/ollamaserver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: '0.30.0'
+appVersion: '0.30.6'
 description: description
 name: ollamaserver
 type: application
-version: 1.1.0
+version: 1.1.1

--- a/ollamav2/ollamaserver/templates/deployment.yaml
+++ b/ollamav2/ollamaserver/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
             runAsUser: 0
       containers:
         - name: ollama
-          image: "docker.io/ollama/ollama:0.30.0"
+          image: "docker.io/ollama/ollama:0.30.6"
           envFrom:
             - configMapRef:
                 name: ollama-env


### PR DESCRIPTION
…resh release notes

Bump the Ollama engine image from 0.30.0 to 0.30.6 (Chart appVersion + OlaresManifest versionName), bump app version 1.1.0 -> 1.1.1 for cache invalidation, and refresh the upgrade notes (EN/ZH) with the v0.30.5 and v0.30.6 changelogs. No startup flag or environment variable changes are required for this upgrade.

### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
> The title of your application appears on Market.

### Description
> Brief description about your application here. 
>
> For app updates, please describe the changes.

### Statement
- [ ] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
