### PR TITLE
[UPDATE][gitlab][1.0.11] enable allowMultipleInstall with per-install IngressClass naming

### DIFF
--- a/gitlab/Chart.yaml
+++ b/gitlab/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.9
+version: 1.0.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/gitlab/OlaresManifest.yaml
+++ b/gitlab/OlaresManifest.yaml
@@ -5,7 +5,7 @@ metadata:
   description: A web-based Git repository management tool.
   icon: https://app.cdn.olares.com/appstore/gitlab/icon.png
   appid: gitlab
-  version: '1.0.9'
+  version: '1.0.11'
   title: GitLab
   categories:
   - Developer Tools
@@ -131,6 +131,7 @@ spec:
   supportArch:
   - amd64
 options:
+  allowMultipleInstall: true
   dependencies:
   - name: olares
     type: system

--- a/gitlab/scripts/render-gitlab-template.py
+++ b/gitlab/scripts/render-gitlab-template.py
@@ -141,6 +141,35 @@ spec:
     return text
 
 
+def apply_namespace_ingress_class(text: str) -> str:
+    """Per-namespace IngressClass name avoids cluster-wide collisions for multi-instance installs."""
+    ingress_class_var = (
+        '{{- /* Per-install IngressClass: Namespace is the primary uniqueness boundary; Name included for Olares allowMultipleInstall lint. */ -}}\n'
+        '{{- $ingressClassName := printf "gitlab-nginx-%s-%s" .Release.Namespace .Release.Name -}}'
+    )
+    if "$ingressClassName" not in text.split("---", 1)[0]:
+        marker = '{{- $workhorseTrusted := concat $trustedProxies (list "127.0.0.1/32") -}}'
+        if marker in text:
+            text = text.replace(marker, ingress_class_var + "\n" + marker, 1)
+
+    text = text.replace("- --ingress-class=nginx\n", "- --ingress-class={{ $ingressClassName }}\n")
+    text = text.replace("- --ingress-class=gitlab-nginx\n", "- --ingress-class={{ $ingressClassName }}\n")
+    text = text.replace(
+        "  name: nginx\nspec:\n  controller: k8s.io/ingress-nginx",
+        "  name: gitlab-nginx-{{ .Release.Namespace }}-{{ .Release.Name }}\nspec:\n  controller: k8s.io/ingress-nginx",
+    )
+    text = text.replace('  name: "gitlab-nginx"\n', "  name: gitlab-nginx-{{ .Release.Namespace }}-{{ .Release.Name }}\n")
+    text = text.replace('  name: {{ $ingressClassName | quote }}\n', "  name: gitlab-nginx-{{ .Release.Namespace }}-{{ .Release.Name }}\n")
+    text = text.replace('  name: gitlab-nginx-{{ .Release.Namespace }}\n', "  name: gitlab-nginx-{{ .Release.Namespace }}-{{ .Release.Name }}\n")
+    text = text.replace('  name: gitlab-nginx-{{ .Release.Name }}\n', "  name: gitlab-nginx-{{ .Release.Namespace }}-{{ .Release.Name }}\n")
+    text = text.replace(
+        'kubernetes.io/ingress.class: "gitlab-nginx"',
+        "kubernetes.io/ingress.class: {{ $ingressClassName | quote }}",
+    )
+    text = text.replace("ingressClassName: gitlab-nginx", "ingressClassName: {{ $ingressClassName }}")
+    return text
+
+
 ROLE_CLUSTER_REPLACEMENT = """# Source: gitlab/charts/nginx-ingress/templates/clusterrole.yaml (namespaced Role; aligns with gitlab-in-olares)
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -303,20 +332,30 @@ def main() -> None:
     if _selfsign_prefix in text and "namespace={{ .Release.Namespace }}\n          certname=gitlab-wildcard-tls" not in text:
         text = text.replace(_selfsign_prefix, _selfsign_prefix_fixed, 1)
 
-    # Olares: nginx controller Deployment name matches previous chart (Service stays gitlab-nginx-ingress-controller)
+    # Olares allowMultipleInstall: nginx controller Deployment uses Release.Name; Service stays gitlab-nginx-ingress-controller
     text = re.sub(
         r"(# Source: gitlab/charts/nginx-ingress/templates/controller-deployment\.yaml\n"
         r"apiVersion: apps/v1\n"
         r"kind: Deployment\n"
         r"metadata:\n"
         r"  labels:[\s\S]*?\n  name: )gitlab-nginx-ingress-controller\n",
-        r"\1gitlab\n",
+        r"\1{{ .Release.Name }}\n",
+        text,
+        count=1,
+    )
+    text = re.sub(
+        r"(# Source: gitlab/charts/nginx-ingress/templates/controller-deployment\.yaml\n"
+        r"apiVersion: apps/v1\n"
+        r"kind: Deployment\n"
+        r"metadata:\n"
+        r"  labels:[\s\S]*?\n  name: )gitlab\n",
+        r"\1{{ .Release.Name }}\n",
         text,
         count=1,
     )
 
-    # Match IngressClass name gitlab-nginx (chart default class name; controller arg must agree)
-    text = text.replace("- --ingress-class=nginx\n", "- --ingress-class=gitlab-nginx\n")
+    # Per-namespace IngressClass (must match Ingress ingressClassName and controller --ingress-class)
+    text = apply_namespace_ingress_class(text)
 
     # Mitigate pthread_create EAGAIN under small limits (same idea as prior gitlab-in-olares patch)
     if "worker-processes:" not in text:
@@ -350,6 +389,7 @@ def main() -> None:
 
     # Kubernetes 1.25+ / Olares: deprecated API versions removed from apiserver
     text = upgrade_k8s_api_versions(text)
+    text = apply_namespace_ingress_class(text)
 
     with open(path_out, "w", encoding="utf-8") as f:
         f.write(text)

--- a/gitlab/templates/gitlab.yaml
+++ b/gitlab/templates/gitlab.yaml
@@ -40,6 +40,8 @@
 {{- if and .Values.runner .Values.runner.ciServerUrl -}}
 {{- $runnerCiServerUrl = .Values.runner.ciServerUrl -}}
 {{- end -}}
+{{- /* Per-install IngressClass: Namespace is the primary uniqueness boundary; Name included for Olares allowMultipleInstall lint. */ -}}
+{{- $ingressClassName := printf "gitlab-nginx-%s-%s" .Release.Namespace .Release.Name -}}
 {{- $workhorseTrusted := concat $trustedProxies (list "127.0.0.1/32") -}}
 ---
 # Source: gitlab/charts/gitlab/charts/gitaly/templates/pdb.yaml
@@ -6007,7 +6009,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     component: "controller"
     app.kubernetes.io/component: controller
-  name: gitlab
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   annotations:
 spec:
@@ -6053,7 +6055,7 @@ spec:
             - --publish-service=$(POD_NAMESPACE)/gitlab-nginx-ingress-controller
             - --election-id=ingress-controller-leader
             - --controller-class=k8s.io/ingress-nginx
-            - --ingress-class=gitlab-nginx
+            - --ingress-class={{ $ingressClassName }}
             - --configmap=$(POD_NAMESPACE)/gitlab-nginx-ingress-controller
             - --tcp-services-configmap={{ .Release.Namespace }}/gitlab-nginx-ingress-tcp
             - --watch-namespace=$(POD_NAMESPACE)
@@ -7453,7 +7455,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     component: "controller"
     app.kubernetes.io/component: controller
-  name: "gitlab-nginx"
+  name: gitlab-nginx-{{ .Release.Namespace }}-{{ .Release.Name }}
 spec:
   controller: k8s.io/ingress-nginx
 ---
@@ -7470,7 +7472,7 @@ metadata:
     heritage: Helm
     
   annotations:
-    kubernetes.io/ingress.class: "gitlab-nginx"
+    kubernetes.io/ingress.class: {{ $ingressClassName | quote }}
     kubernetes.io/ingress.provider: "nginx"
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
     nginx.ingress.kubernetes.io/custom-http-errors: ""
@@ -7487,7 +7489,7 @@ metadata:
       proxy_set_header X-Forwarded-Host {{ $kasDomain }};
 
 spec:
-  ingressClassName: gitlab-nginx
+  ingressClassName: {{ $ingressClassName }}
   rules:
     - host: {{ $kasDomain }}
       http:
@@ -7525,7 +7527,7 @@ metadata:
     gitlab.com/webservice-name: default
     
   annotations:
-    kubernetes.io/ingress.class: "gitlab-nginx"
+    kubernetes.io/ingress.class: {{ $ingressClassName | quote }}
     kubernetes.io/ingress.provider: "nginx"
     
     nginx.ingress.kubernetes.io/proxy-body-size: "512m"
@@ -7545,7 +7547,7 @@ metadata:
       proxy_set_header X-Forwarded-Port 443;
       proxy_set_header X-Forwarded-Host {{ $gitlabDomain }};
 spec:
-  ingressClassName: gitlab-nginx
+  ingressClassName: {{ $ingressClassName }}
   rules:
     - host: {{ $gitlabDomain }}
       http:
@@ -7575,7 +7577,7 @@ metadata:
     heritage: Helm
     
   annotations:
-    kubernetes.io/ingress.class: "gitlab-nginx"
+    kubernetes.io/ingress.class: {{ $ingressClassName | quote }}
     kubernetes.io/ingress.provider: "nginx"
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
@@ -7583,7 +7585,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
     
 spec:
-  ingressClassName: gitlab-nginx
+  ingressClassName: {{ $ingressClassName }}
   rules:
     - host: {{ $minioDomain }}
       http:
@@ -7613,7 +7615,7 @@ metadata:
     heritage: Helm
     
   annotations:
-    kubernetes.io/ingress.class: "gitlab-nginx"
+    kubernetes.io/ingress.class: {{ $ingressClassName | quote }}
     kubernetes.io/ingress.provider: "nginx"
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
@@ -7621,7 +7623,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
     
 spec:
-  ingressClassName: gitlab-nginx
+  ingressClassName: {{ $ingressClassName }}
   rules:
     - host: {{ $registryDomain }}
       http:


### PR DESCRIPTION


### App Title
> gitlab

### Description
> Support installing multiple GitLab instances in the same cluster without colliding on the cluster-scoped IngressClass. Use a release- and namespace- scoped class name (gitlab-nginx-{{ .Release.Namespace }}-{{ .Release.Name }}), keep controller and Ingress references in sync, and name the nginx ingress controller Deployment {{ .Release.Name }} for Olares multi-install checks. Update the render script and bump the chart to 1.0.11.

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
