### PR TITLE
[UPDATE][acestep15v3][1.1.3]migrate download to llm-init download-onl…

### DIFF
--- a/acestep15v3/Chart.yaml
+++ b/acestep15v3/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "0.1.8"
 description: A Step Towards Music Generation Foundation Model.
 name: acestep15v3
 type: application
-version: 1.1.2
+version: 1.1.3

--- a/acestep15v3/OlaresManifest.yaml
+++ b/acestep15v3/OlaresManifest.yaml
@@ -6,7 +6,7 @@ metadata:
   description: The most powerful local music generation model that outperforms most commercial alternatives
   icon: https://app.cdn.olares.com/appstore/acestep/icon2.png
   appid: acestep15v3
-  version: '1.1.2'
+  version: '1.1.3'
   title: ACE-Step 1.5 V3 for test
   categories:
     - Creativity
@@ -24,16 +24,20 @@ entrances:
 
 # Declares every workload's replica count (v3 schema). Keys MUST match the
 # rendered Deployment metadata.name and values.yaml workloads.<name>:
-#   acestep15v3    — nginx entrance Deployment (must match metadata.name / appid)
-#   acestepserver  — ACE-Step 1.5 gradio engine Deployment
-# The download Job carries no replica count.
+#   acestep15v3        — nginx entrance Deployment (must match metadata.name / appid)
+#   acestepserver      — ACE-Step 1.5 gradio engine Deployment
+#   acestepdownloader  — llm-init download-only model fetcher
 workloadReplicas:
   acestep15v3: 1
   acestepserver: 1
+  acestepdownloader: 1
 
 permission:
   appData: true
-  appCache: true
+  appCache: true   # llm-init sentinel/run-state under appCache/llm-init-run/<release>
+  # ACE-Step HF models live in the shared cross-app App Common store
+  # (appCommon/huggingface, mounted at the fixed /cache/hf/hub container path).
+  appCommon: true
   externalData: true
   userData:
     - Home
@@ -77,13 +81,27 @@ spec:
 
     **ACE-Step 1.5 XL (4B DiT)**
     - acestep-v15-xl-base, acestep-v15-xl-sft, acestep-v15-xl-turbo — higher audio quality with 4B-parameter DiT decoder
-    - Requires ≥12GB VRAM (with offload) or ≥20GB recommended; all LM models remain compatible
+    - Requires ≥12GB VRAM; all LM models remain compatible
 
   upgradeDescription: |
     Migrated ACE-Step 1.5 to apiVersion v3 shared app pattern (acestep15v2 → acestep15v3).
 
     **What's Changed**
 
+    - **Download architecture**: replaced the bespoke downloader image + Job with
+      the shared `llm-init` download-only Deployment (`acestepdownloader`),
+      matching speachesv3. Models now land in the shared cross-app HF cache
+      (App Common) and the engine gates on the downloader's `/readyz` instead of
+      per-repo `.done` sentinels. `/app/checkpoints` is now an ephemeral symlink
+      farm over the cached snapshots, so model bytes are de-duplicated and reused
+      across apps. Declared `permission.appCommon: true` for the shared HF store.
+      Downloader image bumped to `llm-init:v1.2.4` (default LFS; chart no longer
+      sets `HF_HUB_DISABLE_XET`).
+    - **Entrance routing**: rewrote nginx to match speachesv3 — llm-init API paths
+      (`/api/progress`, `/healthz`, …) pin to download-svc; `/` gates on model
+      download + Gradio readiness and auto-reloads into the app via `/__app_ready`.
+    - **Resources**: raised nvidia `limitedMemory` to 34Gi so the llm-init downloader
+      (4Gi) + engine (29Gi) + entrance (256Mi) limits sum within the envelope.
     - **Multi-install**: the acestepweb Deployment now uses {{ .Release.Name }} so allowMultipleInstall installs don't collide on workload names.
     - **Accelerator**: declared the GPU requirement via the accelerator modes list (nvidia only; amd64-only app).
 
@@ -94,8 +112,9 @@ spec:
     - **Scaling**: `workloadReplicas` declares replica counts for the
       `acestep15v3` entrance and `acestepserver` gradio engine workloads.
       The model-download Job carries no replicas.
-    - **Runtime**: container image `beclab/ace-step-ace-step-1.5:0.1.8`,
-      default preset acestep-v15-xl-sft + acestep-5Hz-lm-4B with CPU offload.
+    - **Runtime**: manual service initialization in Gradio Settings (disabled
+      `--service_mode` / `--init_service` auto-load); nvidia `requiredGPUMemory`
+      set to 12Gi for acestep-v15-xl-sft + acestep-5Hz-lm-4B.
 
   developer: ace-step
   website: https://acemusic.ai/
@@ -115,7 +134,7 @@ spec:
     requiredCpu: "1"
     limitedCpu: "7"
     requiredMemory: 13Gi
-    limitedMemory: 31Gi
+    limitedMemory: 34Gi
     requiredDisk: 36Gi
     limitedDisk: 100Gi
     requiredGPUMemory: 12Gi

--- a/acestep15v3/templates/acestep15v3.yaml
+++ b/acestep15v3/templates/acestep15v3.yaml
@@ -6,121 +6,95 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   nginx.conf: |
-    lua_shared_dict healthcheck 1m;
-    resolver coredns.kube-system.svc.cluster.local valid=10s;
-
-    init_worker_by_lua_block {
-      if ngx.worker.id() ~= 0 then return end
-
-      local function check_backends(premature)
-        if premature then return end
-        local hc = ngx.shared.healthcheck
-
-        if not hc:get("main_ready") then
-          local sock = ngx.socket.tcp()
-          sock:settimeout(2000)
-          local ok = sock:connect("acestep-svc.{{ .Release.Namespace }}.svc.cluster.local", 7860)
-          if ok then
-            sock:close()
-            hc:set("main_ready", true)
-          end
-        end
-
-        if not hc:get("main_ready") then
-          local sock2 = ngx.socket.tcp()
-          sock2:settimeout(2000)
-          local ok2 = sock2:connect("download-svc.{{ .Release.Namespace }}.svc.cluster.local", 8090)
-          if ok2 then
-            sock2:close()
-            hc:set("download_ready", true)
-          else
-            hc:set("download_ready", false)
-          end
-        end
-
-        ngx.timer.at(3, check_backends)
-      end
-      ngx.timer.at(1, check_backends)
-    }
-
+    # ACE-Step entrance: gate the Gradio app on model download (llm-init /readyz)
+    # AND engine readiness (gradio_api/info). While gated, serve the llm-init
+    # download dashboard; llm-init API paths (/api/progress, /healthz, …) are
+    # pinned to download-svc so they never fall through to Gradio (404).
     server {
         listen 8080;
         access_log /opt/bitnami/openresty/nginx/logs/access.log;
         error_log /opt/bitnami/openresty/nginx/logs/error.log;
 
-        set $main_backend "acestep-svc.{{ .Release.Namespace }}.svc.cluster.local:7860";
-        set $download_backend "download-svc.{{ .Release.Namespace }}.svc.cluster.local:8090";
+        client_max_body_size 500m;
+        proxy_buffering off;
+        proxy_redirect off;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 1800s;
+        proxy_read_timeout 1800s;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
 
-        location /progress {
-            set $backend "";
-            access_by_lua_block {
-              if ngx.shared.healthcheck:get("download_ready") then
-                ngx.var.backend = ngx.var.download_backend
-              else
-                ngx.header["Content-Type"] = "application/json"
-                ngx.say('{"status":"waiting"}')
-                return ngx.exit(200)
-              end
-            }
-            proxy_pass http://$backend;
-            proxy_http_version 1.1;
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Host $http_host;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-            add_header Access-Control-Allow-Origin *;
-            if ($request_method = 'OPTIONS') { return 204; }
+        resolver coredns.kube-system.svc.cluster.local valid=10s;
+
+        # llm-init control-plane API — always reach the downloader, not Gradio.
+        location /api/ {
+            proxy_pass http://download-svc.{{ .Release.Namespace }}.svc.cluster.local:8090;
+        }
+        location /static/ {
+            proxy_pass http://download-svc.{{ .Release.Namespace }}.svc.cluster.local:8090;
+        }
+        location = /healthz {
+            proxy_pass http://download-svc.{{ .Release.Namespace }}.svc.cluster.local:8090/healthz;
+        }
+        location = /livez {
+            proxy_pass http://download-svc.{{ .Release.Namespace }}.svc.cluster.local:8090/livez;
+        }
+        location = /readyz {
+            proxy_pass http://download-svc.{{ .Release.Namespace }}.svc.cluster.local:8090/readyz;
+        }
+        # Legacy harveyff progress path → llm-init progress snapshot.
+        location = /progress {
+            proxy_pass http://download-svc.{{ .Release.Namespace }}.svc.cluster.local:8090/api/progress;
         }
 
-        location = /gradio_api/info {
-            proxy_connect_timeout 2s;
+        # Internal gates for auth_request / auto-reload polling.
+        location = /__models_ready {
+            internal;
+            proxy_pass http://download-svc.{{ .Release.Namespace }}.svc.cluster.local:8090/readyz;
+            proxy_pass_request_body off;
+            proxy_set_header Content-Length "";
+            proxy_connect_timeout 3s;
             proxy_read_timeout 5s;
-            proxy_pass http://$main_backend;
-            proxy_http_version 1.1;
-            proxy_set_header Host $host;
-            proxy_intercept_errors on;
-            error_page 502 504 = @probe_not_ready;
-            log_by_lua_block {
-              if ngx.status == 200 then
-                ngx.shared.healthcheck:set("main_ready", true)
-              end
-            }
+            proxy_send_timeout 5s;
         }
-
-        location @probe_not_ready {
-            default_type application/json;
-            return 503 '{"error":"service not ready"}';
+        location = /__main_ready {
+            internal;
+            proxy_pass http://acestep-svc.{{ .Release.Namespace }}.svc.cluster.local:7860/gradio_api/info;
+            proxy_pass_request_body off;
+            proxy_set_header Content-Length "";
+            proxy_connect_timeout 3s;
+            proxy_read_timeout 5s;
+            proxy_send_timeout 5s;
+        }
+        # Public: 200 once models are on disk AND Gradio is answering.
+        location = /__app_ready {
+            default_type text/plain;
+            content_by_lua_block {
+                local models = ngx.location.capture("/__models_ready")
+                if models.status ~= 200 then
+                    ngx.status = 503
+                    return
+                end
+                local main = ngx.location.capture("/__main_ready")
+                if main.status ~= 200 then
+                    ngx.status = 503
+                    return
+                end
+                ngx.status = 200
+                ngx.say("ok")
+            }
         }
 
         location / {
-            set $backend "";
-            access_by_lua_block {
-              if ngx.shared.healthcheck:get("main_ready") then
-                ngx.var.backend = ngx.var.main_backend
-              elseif ngx.shared.healthcheck:get("download_ready") then
-                ngx.var.backend = ngx.var.download_backend
-              else
-                ngx.header["Content-Type"] = "text/html; charset=utf-8"
-                ngx.say([[<!DOCTYPE html>
-    <html><head><meta charset="utf-8"><title>ACE-Step 1.5</title>
-    <style>body{display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0;background:#1a1a2e;color:#e0e0e0;font-family:system-ui,sans-serif}
-    .c{text-align:center}.spinner{width:48px;height:48px;border:4px solid #333;border-top-color:#7c3aed;border-radius:50%;animation:spin 1s linear infinite;margin:0 auto 24px}
-    @keyframes spin{to{transform:rotate(360deg)}}h1{font-size:1.5rem;margin-bottom:8px}p{color:#888;font-size:0.95rem}</style></head>
-    <body><div class="c"><div class="spinner"></div><h1>Initializing...</h1><p>Downloading models or starting services. This page will refresh automatically.</p></div>
-    <script>setTimeout(function(){location.reload()},5000)</script></body></html>]])
-                return ngx.exit(200)
-              end
-            }
-
-            proxy_pass http://$backend;
-            proxy_connect_timeout 10s;
-            proxy_send_timeout 300s;
-            proxy_read_timeout 1800s;
-            proxy_http_version 1.1;
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Host $http_host;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
+            auth_request /__models_ready;
+            error_page 401 403 500 502 503 504 = @downloader;
+            proxy_pass http://acestep-svc.{{ .Release.Namespace }}.svc.cluster.local:7860;
             add_header X-Frame-Options "";
             add_header Access-Control-Allow-Origin *;
             add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS, HEAD";
@@ -131,6 +105,18 @@ data:
               add_header Access-Control-Allow-Headers "deviceType,token,authorization,content-type,x-csrftoken";
               return 204;
             }
+        }
+
+        # llm-init download dashboard + auto-reload once /__app_ready flips 200.
+        location @downloader {
+            proxy_pass http://download-svc.{{ .Release.Namespace }}.svc.cluster.local:8090;
+            proxy_set_header Accept-Encoding "";
+            sub_filter_once on;
+            sub_filter_types text/html;
+            sub_filter '</body>' '<script>(function(){function c(){fetch("/__app_ready",{cache:"no-store"}).then(function(r){if(r.ok){location.reload();}}).catch(function(){});}setInterval(c,3000);})();</script></body>';
+            proxy_connect_timeout 10s;
+            proxy_read_timeout 120s;
+            proxy_send_timeout 120s;
         }
     }
 

--- a/acestep15v3/templates/download.yaml
+++ b/acestep15v3/templates/download.yaml
@@ -1,68 +1,160 @@
+{{- /* llm-init in download-only mode (ENGINE_KIND empty): no engine is started
+       or proxied; llm-init degrades to a pure model downloader that drops the
+       three ACE-Step repos into the shared cross-app HF Hub cache (App Common,
+       fixed /cache/hf/hub). The acestepserver engine mounts the same store and
+       waits on /readyz before materialising the flat /app/checkpoints layout it
+       expects (see server.yaml).
+
+       Three HF repos via the comma form: the first segment is ROLE=main, the
+       rest ROLE=extra automatically (the index form would default every entry
+       to main and fail the "multiple ROLE=main" check). All must be hf://
+       (ollama:// sources are rejected in download-only mode). */ -}}
+{{- $oe := .Values.olaresEnv | default dict -}}
+{{- $hfEndpoint := $oe.HF_ENDPOINT | default "" -}}
+{{- $hfToken := $oe.HF_TOKEN | default "" -}}
+{{- /* Per-release run-state hostPath so concurrent clones on the same node do
+       not collide on the sentinel. */ -}}
+{{- $runStateHostPath := printf "%s/llm-init-run/%s" .Values.userspace.appCache .Release.Name -}}
 ---
-apiVersion: batch/v1
-kind: Job
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-download-models
-  namespace: {{ .Release.Namespace }}
+  # Static name matching workloadReplicas + values.workloads. Label stays
+  # io.kompose.service: llm-init so download-svc resolves here.
+  name: acestepdownloader
+  namespace: '{{ .Release.Namespace }}'
   labels:
-    app: {{ .Release.Name }}-download-models
+    io.kompose.service: llm-init
 spec:
-  ttlSecondsAfterFinished: 100
-  backoffLimit: 3
+  replicas: {{ .Values.workloads.acestepdownloader.replicaCount }}
+  selector:
+    matchLabels:
+      io.kompose.service: llm-init
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-download-models
+        io.kompose.network/chrome-default: "true"
+        io.kompose.service: llm-init
     spec:
-      restartPolicy: OnFailure
-      containers:
-        - name: download-model
-          image: "docker.io/beclab/harveyff-hf-downloader-only:v0.0.7"
-          env:
-            - name: HF_ENDPOINT
-              value: "{{ .Values.olaresEnv.HF_ENDPOINT }}"
-          args:
-            - "--tasks"
-            - '{"tasks":[{"repo":"ACE-Step/Ace-Step1.5","file":"","ref":"main","outDir":"/app/checkpoints","doneNameTpl":".Ace-Step1.5.done"},{"repo":"ACE-Step/acestep-v15-xl-sft","file":"","ref":"main","outDir":"/app/checkpoints/acestep-v15-xl-sft","doneNameTpl":".acestep-v15-xl-sft.done"},{"repo":"ACE-Step/acestep-5Hz-lm-4B","file":"","ref":"main","outDir":"/app/checkpoints/acestep-5Hz-lm-4B","doneNameTpl":".acestep-5Hz-lm-4B.done"}]}'
-            - "--static"
-            - "/app/static"
-            - "--port"
-            - "8090"
-            - "--probe-url"
-            - "/gradio_api/info"
-          ports:
-            - containerPort: 8090
-              name: http
+      restartPolicy: Always
+      volumes:
+        # Shared cross-app HF Hub cache (App Common); image bakes HF_HUB_CACHE=/cache/hf/hub.
+        - name: hf-cache
+          hostPath:
+            path: "{{ .Values.userspace.appCommon }}/huggingface"
+            type: DirectoryOrCreate
+        # Per-release sentinel / run-state dir (App Cache).
+        - name: run-state
+          hostPath:
+            path: "{{ $runStateHostPath }}"
+            type: DirectoryOrCreate
+      initContainers:
+        # hostPath dirs are created root-owned; llm-init runs as UID 1000.
+        - name: init-chown
+          image: docker.io/beclab/aboveos-busybox:1.37.0
+          command:
+            - sh
+            - -c
+            - "chown 1000:1000 /cache/hf/hub /run/llm-init || true"
           volumeMounts:
-            - name: checkpoints
-              mountPath: /app/checkpoints
+            - name: hf-cache
+              mountPath: /cache/hf/hub
+            - name: run-state
+              mountPath: /run/llm-init
+          securityContext:
+            runAsUser: 0
+      containers:
+        - name: llm-init
+          # v1.2.4: comma multi-source, nullengine download-only, default LFS
+          # (hf_xet off unless HF_ENABLE_XET=true).
+          image: docker.io/beclab/llm-init:v1.2.4
+          imagePullPolicy: IfNotPresent
+          env:
+            # Empty ENGINE_KIND selects download-only mode (nullengine).
+            - name: ENGINE_KIND
+              value: ""
+            # TEMPORARY (llm-init v1.2.3 image): download-only still requires
+            # MODEL_NAME + MODEL_MODE (the "make-optional" patch is not yet in a
+            # released tag). They are placeholders only — the repos to fetch come
+            # entirely from MODEL_SOURCE. Drop both once the patched image ships.
+            - name: MODEL_NAME
+              value: "ACE-Step/Ace-Step1.5"
+            - name: MODEL_MODE
+              value: "chat"
+            # Comma multi-source (v1.2.x): first segment is ROLE=main, the rest
+            # are ROLE=extra automatically and are pre-fetched before main. Full
+            # repos (no --include); all must be hf://.
+            - name: MODEL_SOURCE
+              value: "hf://ACE-Step/Ace-Step1.5,hf://ACE-Step/acestep-v15-xl-sft,hf://ACE-Step/acestep-5Hz-lm-4B"
+            # Always wire the Olares HF mirror (manifest requires HF_ENDPOINT).
+            - name: HF_ENDPOINT
+              value: "{{ $oe.HF_ENDPOINT }}"
+{{- if $hfToken }}
+            - name: HF_TOKEN
+              value: "{{ $hfToken }}"
+{{- end }}
+            # Large full-repo downloads: keep concurrency low. LFS is the image
+            # default in v1.2.4 (stable memory; opt into xet via HF_ENABLE_XET).
+            - name: MAX_CONCURRENT_DOWNLOADS
+              value: "1"
+            - name: RUN_DIR
+              value: /run/llm-init
+            - name: PORT
+              value: "8090"
+            - name: LOG_FORMAT
+              value: json
+          ports:
+            - name: http
+              containerPort: 8090
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 8090
+            periodSeconds: 30
+            timeoutSeconds: 5
+          # Readiness on /livez (process up), not /readyz (model ready), so the
+          # downloader stays scheduled and serving progress while downloading.
+          readinessProbe:
+            httpGet:
+              path: /livez
+              port: 8090
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          volumeMounts:
+            - name: hf-cache
+              mountPath: /cache/hf/hub
+            - name: run-state
+              mountPath: /run/llm-init
           resources:
             requests:
               cpu: 100m
-              memory: 200Mi
+              memory: 128Mi
             limits:
-              cpu: "1"
-              memory: 1Gi
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
-          imagePullPolicy: IfNotPresent
-      volumes:
-        - name: checkpoints
-          hostPath:
-            path: "{{ .Values.sharedlib }}/ai/acestep15v3"
-            type: DirectoryOrCreate
-
+              cpu: 500m
+              # `hf download` runs a python subprocess in this same cgroup. The
+              # ACE-Step repos are large and sharded; 4Gi gives the huggingface_hub
+              # CLI (--max-workers 1) headroom on multi-GB checkpoint downloads.
+              memory: 4Gi
 ---
+# Internal progress / health surface (no entrance). acestepserver waits on
+# /readyz here before reading the shared cache; the nginx entrance also TCP-probes
+# this Service to decide between the download dashboard and the engine.
 apiVersion: v1
 kind: Service
 metadata:
   name: download-svc
   namespace: {{ .Release.Namespace }}
+  labels:
+    io.kompose.service: llm-init
 spec:
   selector:
-    app: {{ .Release.Name }}-download-models
+    io.kompose.service: llm-init
   ports:
-    - name: download-status
+    - name: http
       port: 8090
       targetPort: 8090
   type: ClusterIP

--- a/acestep15v3/templates/server.yaml
+++ b/acestep15v3/templates/server.yaml
@@ -43,32 +43,71 @@ spec:
             - '-c'
             - |
               set -e
-              MAIN_DONE="/app/checkpoints/.Ace-Step1.5.done"
-              XL_DONE="/app/checkpoints/acestep-v15-xl-sft/.acestep-v15-xl-sft.done"
-              LM_DONE="/app/checkpoints/acestep-5Hz-lm-4B/.acestep-5Hz-lm-4B.done"
-              echo "[wait] Waiting for model downloads..."
-              while [ ! -f "$MAIN_DONE" ] || [ ! -f "$XL_DONE" ] || [ ! -f "$LM_DONE" ]; do
-                echo "[wait] main=$([ -f "$MAIN_DONE" ] && echo ok || echo pending) xl-sft=$([ -f "$XL_DONE" ] && echo ok || echo pending) lm-4b=$([ -f "$LM_DONE" ] && echo ok || echo pending)"
+              CACHE=/cache/hf/hub
+              READYZ="http://download-svc.{{ .Release.Namespace }}.svc.cluster.local:8090/readyz"
+
+              # Gate on the llm-init downloader (download-only mode) reporting all
+              # repos present. /readyz flips to 200 only once every MODEL_SOURCE
+              # repo is fully on disk, so this replaces the old per-repo .done
+              # sentinel files written by the bespoke downloader.
+              echo "[wait] Waiting for llm-init downloader (/readyz)..."
+              until python3 - "$READYZ" <<'RDY_EOF' 2>/dev/null
+              import sys, urllib.request
+              try:
+                  with urllib.request.urlopen(sys.argv[1], timeout=5) as r:
+                      sys.exit(0 if r.status == 200 else 1)
+              except Exception:
+                  sys.exit(1)
+              RDY_EOF
+              do
+                echo "[wait] downloader not ready yet..."
                 sleep 10
               done
-              echo "[wait] All required models ready, starting ACE-Step server."
+              echo "[wait] downloader ready; materialising /app/checkpoints from HF cache."
+
+              # llm-init writes the standard HF cache snapshot layout
+              # ($CACHE/models--ACE-Step--<repo>/snapshots/<sha>/...), but ACE-Step
+              # loads flat dirs under /app/checkpoints. Rebuild that flat view as a
+              # symlink farm pointing at the resolved snapshots. The snapshot's
+              # internal blob symlinks are relative to $CACHE (mounted here at the
+              # same path), so they resolve transparently.
+              snap() {  # $1 = models--ACE-Step--<repo> dir name -> prints snapshot dir
+                ref="$CACHE/$1/refs/main"
+                if [ -f "$ref" ]; then
+                  echo "$CACHE/$1/snapshots/$(cat "$ref")"
+                else
+                  ls -d "$CACHE/$1"/snapshots/*/ 2>/dev/null | head -1
+                fi
+              }
+              MAIN_SNAP="$(snap models--ACE-Step--Ace-Step1.5)"
+              XL_SNAP="$(snap models--ACE-Step--acestep-v15-xl-sft)"
+              LM_SNAP="$(snap models--ACE-Step--acestep-5Hz-lm-4B)"
+              mkdir -p /app/checkpoints
+              # Ace-Step1.5 base model lands at the checkpoints root: link each
+              # top-level entry (visible + dotfiles) individually.
+              for f in "$MAIN_SNAP"/* "$MAIN_SNAP"/.[!.]*; do
+                [ -e "$f" ] || continue
+                ln -sfn "$f" "/app/checkpoints/$(basename "$f")"
+              done
+              # The XL-SFT and LM repos are referenced as their own subdirs
+              # (ACESTEP_CONFIG_PATH / ACESTEP_LM_MODEL_PATH).
+              ln -sfn "${XL_SNAP%/}" /app/checkpoints/acestep-v15-xl-sft
+              ln -sfn "${LM_SNAP%/}" /app/checkpoints/acestep-5Hz-lm-4B
+              echo "[wait] checkpoints ready, starting ACE-Step server."
 
               cd /app
               if [ -x /app/docker-entrypoint.sh ]; then
                 export ACESTEP_MODE=gradio
-                export ACESTEP_INIT_SERVICE=true
+                export ACESTEP_INIT_SERVICE=false
                 export GRADIO_SERVER_NAME=0.0.0.0
                 export GRADIO_PORT=7860
-                export ACESTEP_EXTRA_ARGS="--service_mode true --language ${ACESTEP_UI_LANGUAGE:-en} --device ${ACESTEP_DEVICE:-auto}"
+                export ACESTEP_EXTRA_ARGS="--language ${ACESTEP_UI_LANGUAGE:-en} --device ${ACESTEP_DEVICE:-auto}"
                 exec /app/docker-entrypoint.sh
               fi
 
               exec uv run python -m acestep.acestep_v15_pipeline \
                 --server-name 0.0.0.0 \
                 --port 7860 \
-                --init_service true \
-                --service_mode true \
-                --init_llm true \
                 --config_path "${ACESTEP_CONFIG_PATH}" \
                 --lm_model_path "${ACESTEP_LM_MODEL_PATH}" \
                 --backend "${ACESTEP_LLM_BACKEND:-pt}" \
@@ -86,7 +125,7 @@ spec:
             - name: ACESTEP_CONFIG_PATH
               value: "acestep-v15-xl-sft"
             - name: ACESTEP_INIT_SERVICE
-              value: "true"
+              value: "false"
             - name: ACESTEP_LM_MODEL_PATH
               value: "acestep-5Hz-lm-4B"
             - name: ACESTEP_LLM_BACKEND
@@ -124,15 +163,23 @@ spec:
           volumeMounts:
             - name: checkpoints
               mountPath: /app/checkpoints
+            # Shared cross-app HF Hub cache (App Common), populated by the
+            # llm-init downloader. Read here to build the checkpoints symlink farm.
+            - name: hf-cache
+              mountPath: /cache/hf/hub
             - name: outputs
               mountPath: /app/gradio_outputs
             - name: logs
               mountPath: /app/logs
           imagePullPolicy: IfNotPresent
       volumes:
+        # /app/checkpoints is now an ephemeral symlink farm rebuilt on every
+        # start; the real model bytes persist in the shared HF cache below.
         - name: checkpoints
+          emptyDir: {}
+        - name: hf-cache
           hostPath:
-            path: "{{ .Values.sharedlib }}/ai/acestep15v3"
+            path: "{{ .Values.userspace.appCommon }}/huggingface"
             type: DirectoryOrCreate
         - name: outputs
           hostPath:

--- a/acestep15v3/values.yaml
+++ b/acestep15v3/values.yaml
@@ -1,9 +1,12 @@
 # Per-workload replica counts (keys match Deployment metadata.name and
-# workloadReplicas in OlaresManifest). The download Job carries no replicas.
-#   acestep15v3    — nginx entrance Deployment (must match metadata.name / appid)
-#   acestepserver  — ACE-Step 1.5 gradio engine Deployment
+# workloadReplicas in OlaresManifest).
+#   acestep15v3        — nginx entrance Deployment (must match metadata.name / appid)
+#   acestepserver      — ACE-Step 1.5 gradio engine Deployment
+#   acestepdownloader  — llm-init download-only model fetcher
 workloads:
   acestep15v3:
     replicaCount: 1
   acestepserver:
+    replicaCount: 1
+  acestepdownloader:
     replicaCount: 1


### PR DESCRIPTION
…y architecture

Replace the bespoke harveyff downloader Job with the shared llm-init download-only Deployment (acestepdownloader), matching speachesv3:

- Models land in the shared cross-app HF cache (App Common, /cache/hf/hub); declared permission.appCommon. The engine gates on the downloader's /readyz and materialises the flat /app/checkpoints layout via a symlink farm over the HF snapshots (checkpoints is now an emptyDir).
- Downloader image llm-init:v1.2.4 (default LFS; MAX_CONCURRENT_DOWNLOADS=1 for the large sharded ACE-Step repos).
- Rewrote the nginx entrance to match speachesv3: llm-init API paths (/api/progress, /healthz) pin to download-svc; / gates on model download
  + Gradio readiness and auto-reloads into the app via /__app_ready.
- Manual service initialization in Gradio Settings (disabled service_mode / init_service auto-load).
- nvidia accelerator: requiredGPUMemory 12Gi, limitedMemory 34Gi so the downloader (4Gi) + engine (29Gi) + entrance (256Mi) limits stay within the envelope.

### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
> The title of your application appears on Market.

### Description
> Brief description about your application here. 
>
> For app updates, please describe the changes.

### Statement
- [ ] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
