### PR TITLE
[UPDATE][sglangllmbasev3][1.2.5]bump llm-init to v1.2.4 (default LFS …

### DIFF
--- a/sglangllmbasev3/Chart.yaml
+++ b/sglangllmbasev3/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.5.12.post1
 description: Generic SGLang + llm-init base; the model is supplied at install time via env
 name: sglangllmbasev3
 type: application
-version: 1.2.4
+version: 1.2.5

--- a/sglangllmbasev3/OlaresManifest.yaml
+++ b/sglangllmbasev3/OlaresManifest.yaml
@@ -7,7 +7,7 @@ metadata:
   description: "Generic SGLang + llm-init base. Pick any HF model at install via env."
   appid: sglangllmbasev3
   title: SGLang LLM Base (llm-init)
-  version: '1.2.4'
+  version: '1.2.5'
   categories:
     - AI
 sharedEntrances:
@@ -78,8 +78,11 @@ spec:
     - SGLang also honors `--mem-fraction-static` via `ENGINE_ARGS`.
 
   upgradeDescription: |
-    Generic SGLang + llm-init base (llm-init v1.2.3, lmsysorg/sglang:v0.5.12.post1-cu130).
+    Generic SGLang + llm-init base (llm-init v1.2.4, lmsysorg/sglang:v0.5.12.post1-cu130).
     Loads any HF model; model identity, source and tuning are install-time env.
+    v1.2.5: bump llm-init to v1.2.4 — default to the stable LFS download path
+    (hf_xet disabled unless HF_ENABLE_XET=true) to avoid the hf_xet chunk-buffer
+    OOM on large sharded models (huggingface_hub#3300). No resource-value change.
     v1.2.4: fix Helm render — the v1.2.3 gpumem comment used a Go-template comment
     whose trim markers ({{- ... -}}) collapsed resources:/requests: onto one line;
     switched to a plain YAML (#) comment. No resource-value change.

--- a/sglangllmbasev3/templates/llm-init.yaml
+++ b/sglangllmbasev3/templates/llm-init.yaml
@@ -63,7 +63,10 @@ spec:
               mountPath: /run/llm-init
       containers:
         - name: llm-init
-          image: docker.io/beclab/llm-init:v1.2.3
+          # v1.2.4 defaults to the stable LFS download path (hf_xet disabled
+          # unless HF_ENABLE_XET=true); LFS streams each file to disk with a
+          # bounded RAM footprint, avoiding the hf_xet OOM (huggingface_hub#3300).
+          image: docker.io/beclab/llm-init:v1.2.4
           imagePullPolicy: IfNotPresent
           env:
             - name: ENGINE_KIND
@@ -125,13 +128,10 @@ spec:
               cpu: 200m
               memory: 256Mi
             limits:
-              # hf_xet fetches byte-range chunks in parallel and buffers them in
-              # RAM before flushing to disk (huggingface_hub#3300); the default
-              # 16-way per-file concurrency, times MAX_CONCURRENT_DOWNLOADS
-              # parallel files, can spike well past 1Gi on large sharded models
-              # and OOM-kill this init container mid-download. 4Gi covers the
-              # common single-file / small-sharded GGUF case; very large sharded
-              # models may need more (or the planned llm-init concurrency cap).
+              # LFS download (v1.2.4 default) streams each file to disk with a
+              # bounded footprint, but `hf download` still runs a python
+              # subprocess in this cgroup; 4Gi gives the huggingface_hub CLI
+              # comfortable headroom on large sharded models.
               cpu: "1"
               memory: 4Gi
 ---


### PR DESCRIPTION
…download)

llm-init image v1.2.3 -> v1.2.4, which defaults to the stable LFS download path (hf_xet disabled unless HF_ENABLE_XET=true). LFS streams each file to disk with a bounded RAM footprint, avoiding the hf_xet chunk-buffer OOM on large sharded models (huggingface_hub#3300). No resource-value change.

### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
> The title of your application appears on Market.

### Description
> Brief description about your application here. 
>
> For app updates, please describe the changes.

### Statement
- [ ] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
