### PR TITLE
[UPDATE][llamacppllmbasev3][1.2.6]bump engine to cuda12-b9603 for MTP…

### DIFF
--- a/llamacppllmbasev3/Chart.yaml
+++ b/llamacppllmbasev3/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: b9426
+appVersion: b9603
 description: Generic llama.cpp + llm-init base; the GGUF model is supplied at install time via env
 name: llamacppllmbasev3
 type: application
-version: 1.2.5
+version: 1.2.6

--- a/llamacppllmbasev3/OlaresManifest.yaml
+++ b/llamacppllmbasev3/OlaresManifest.yaml
@@ -7,7 +7,7 @@ metadata:
   description: "Generic llama.cpp + llm-init base. Pick any GGUF model at install via env."
   appid: llamacppllmbasev3
   title: llama.cpp LLM Base (llm-init)
-  version: '1.2.5'
+  version: '1.2.6'
   categories:
     - AI
 sharedEntrances:
@@ -32,7 +32,7 @@ workloadReplicas:
   llamacppllmbasev3: 1
   llminit: 1
 spec:
-  versionName: 'b9426'
+  versionName: 'b9603'
   fullDescription: |
     **IMPORTANT NOTE**
     This is a shared app and a generic *base*: it is NOT tied to any specific
@@ -82,14 +82,19 @@ spec:
     - GPU offload via `-ngl all` in `ENGINE_ARGS`; without `-ngl`, runs on CPU.
 
   upgradeDescription: |
-    Generic llama.cpp + llm-init base (llm-init v1.2.4, beclab/ggml-org-llama.cpp:server-cuda12-b9426).
+    Generic llama.cpp + llm-init base (llm-init v1.2.4, beclab/ggml-org-llama.cpp:server-cuda12-b9603).
     Loads any GGUF model; model identity, source and tuning are install-time env.
+    v1.2.6: bump llama.cpp engine to server-cuda12-b9603 (build b9603, kept on
+    CUDA 12 for driver compatibility) from server-cuda12-b9426. Adds Multi-Token
+    Prediction (MTP) speculative decoding for MTP-capable GGUFs (e.g. Qwen3.6 *-MTP);
+    enable at install via ENGINE_ARGS: --spec-type draft-mtp --spec-draft-n-max 2.
+    No resource-value change.
     v1.2.5: bump llm-init to v1.2.4 — default to the stable LFS download path
     (hf_xet disabled unless HF_ENABLE_XET=true) to avoid the hf_xet chunk-buffer
     OOM on large sharded models (huggingface_hub#3300). No resource-value change.
     v1.2.4: fix Helm render — the v1.2.3 gpumem comment used a Go-template comment
-    whose trim markers ({{- ... -}}) collapsed resources:/requests: onto one line;
-    switched to a plain YAML (#) comment. No resource-value change.
+    whose trim markers collapsed resources/requests onto one line; switched to a
+    plain YAML (#) comment. No resource-value change.
     v1.2.3: set nvidia.com/gpumem on BOTH requests and limits (non-overcommittable
     extended resource; the gpu-inject webhook / auto-gpumem template apps read it
     from limits). gb10 unaffected (unified memory uses pod memory).

--- a/llamacppllmbasev3/README.md
+++ b/llamacppllmbasev3/README.md
@@ -3,9 +3,9 @@
 通用 **llama.cpp + llm-init** 基座，结构与 `vllmllmbasev3` / `sglangllmbasev3` 平行，
 但引擎换成 llama.cpp、模型格式换成 **GGUF**。
 
-- **引擎镜像**: `beclab/ggml-org-llama.cpp:server-cuda12-b9426`（GPU / CUDA 12）
-- **llm-init**: `beclab/llm-init:v1.2.1`
-- **版本**: chart `1.0.0` / appVersion `b9426`
+- **引擎镜像**: `beclab/ggml-org-llama.cpp:server-cuda12-b9603`（GPU / CUDA 12）
+- **llm-init**: `beclab/llm-init:v1.2.4`
+- **版本**: chart `1.2.6` / appVersion `b9603`
 
 ## 架构
 

--- a/llamacppllmbasev3/templates/llamacpp.yaml
+++ b/llamacppllmbasev3/templates/llamacpp.yaml
@@ -72,7 +72,7 @@ spec:
             defaultMode: 0555
       containers:
         - name: llamacpp
-          image: docker.io/beclab/ggml-org-llama.cpp:server-cuda12-b9426
+          image: docker.io/beclab/ggml-org-llama.cpp:server-cuda12-b9603
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh", "/llm-init/wrappers/llamacpp.sh"]
           env:


### PR DESCRIPTION
… support

Bump llama.cpp engine image from server-cuda12-b9426 to server-cuda12-b9603, which adds Multi-Token Prediction (MTP) speculative-decoding support (--spec-type draft-mtp). Kept on the CUDA 12 runtime line for driver compatibility. No resource-value change.

- Chart.yaml / OlaresManifest.yaml: version 1.2.5 -> 1.2.6, versionName b9603
- templates/llamacpp.yaml: engine image -> server-cuda12-b9603
- README / upgradeDescription updated

### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
> The title of your application appears on Market.

### Description
> Brief description about your application here. 
>
> For app updates, please describe the changes.

### Statement
- [ ] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
