### PR TITLE
[UPDATE][deepseekocrwebuiv3][1.1.8]switch download to llm-init (share…

### DIFF
--- a/deepseekocrwebuiv3/Chart.yaml
+++ b/deepseekocrwebuiv3/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "2.0.3"
 description: DeepSeek-OCR-WebUI is an intelligent image recognition web application based on the DeepSeek-OCR-2 model
 name: deepseekocrwebuiv3
 type: application
-version: 1.1.7
+version: 1.1.8

--- a/deepseekocrwebuiv3/OlaresManifest.yaml
+++ b/deepseekocrwebuiv3/OlaresManifest.yaml
@@ -6,7 +6,7 @@ metadata:
   description: Ready-to-use DeepSeek-OCR-2 Web UI
   icon: https://app.cdn.olares.com/appstore/deepseekocr/icon.png
   appid: deepseekocrwebuiv3
-  version: '1.1.7'
+  version: '1.1.8'
   title: DeepSeek-OCR2 WebUI V3
   categories:
     - AI
@@ -34,7 +34,10 @@ workloadReplicas:
 
 permission:
   appData: true
-  appCache: true
+  appCache: true   # llm-init sentinel/run-state under appCache/llm-init-run/<release>
+  # DeepSeek-OCR-2 HF model lives in the shared cross-app App Common store
+  # (appCommon/huggingface, mounted at the fixed /cache/hf/hub container path).
+  appCommon: true
   userData:
     - Home
 
@@ -64,6 +67,19 @@ spec:
     - ModelScope Fallback - Auto-switch to ModelScope when HuggingFace is unavailable
 
   upgradeDescription: |
+    v1.1.8: **Download architecture** — replaced the bespoke harveyff-hf-downloader
+    image with the shared `llm-init` download-only Deployment (`deepseekocrwebuiv3download`,
+    image llm-init:v1.2.4, default LFS). The DeepSeek-OCR-2 model now lands in the
+    shared cross-app HF cache (App Common, /cache/hf/hub) and is de-duplicated/reused
+    across apps. The OCR engine gates on the downloader's `/readyz` instead of the
+    `.DeepSeek-OCR-2.done` sentinel, and `/app/models` is now an ephemeral symlink farm
+    over the cached snapshot. Declared `permission.appCommon: true`. Raised nvidia-gb10
+    `limitedMemory` to 28Gi so the engine (23Gi) + downloader (4Gi) + nginx (0.5Gi)
+    limits sum within the envelope.
+    Entrance: rewrote the nginx clientproxy to the llm-init dashboard pattern — API
+    paths (/api/, /healthz, /readyz, …) pin to download-svc; `/` gates on model
+    download + OCR-app readiness and auto-reloads into the app via `/__app_ready`.
+
     Migrated DeepSeek-OCR-2 WebUI to apiVersion v3 shared app pattern (deepseekocrwebuiv2 → deepseekocrwebuiv3).
 
     **What's Changed**
@@ -109,7 +125,7 @@ spec:
     requiredCpu: "1"
     limitedCpu: "6"
     requiredMemory: 16Gi
-    limitedMemory: 25Gi
+    limitedMemory: 28Gi
     requiredDisk: 8Gi
     limitedDisk: 20Gi
 

--- a/deepseekocrwebuiv3/i18n/en-US/OlaresManifest.yaml
+++ b/deepseekocrwebuiv3/i18n/en-US/OlaresManifest.yaml
@@ -21,6 +21,12 @@ spec:
     - Auto Model Download - Built-in HuggingFace model downloader with progress tracking
     - ModelScope Fallback - Auto-switch to ModelScope when HuggingFace is unavailable
   upgradeDescription: |
+    v1.1.8: replaced the bespoke downloader with the shared llm-init download-only
+    Deployment (image llm-init:v1.2.4, default LFS). The model now lands in the shared
+    cross-app HF cache (App Common) and the OCR engine gates on /readyz; /app/models is a
+    symlink farm over the cached snapshot. Declared permission.appCommon: true and raised
+    nvidia-gb10 limitedMemory to 28Gi for the downloader's larger memory limit.
+
     Migrated DeepSeek-OCR-2 WebUI to apiVersion v3 shared app pattern (deepseekocrwebuiv2 → deepseekocrwebuiv3).
 
     **What's Changed**

--- a/deepseekocrwebuiv3/i18n/zh-CN/OlaresManifest.yaml
+++ b/deepseekocrwebuiv3/i18n/zh-CN/OlaresManifest.yaml
@@ -21,6 +21,11 @@ spec:
     - 自动模型下载 - 内置 HuggingFace 模型下载器，支持进度追踪
     - ModelScope 备选 - HuggingFace 不可用时自动切换到 ModelScope
   upgradeDescription: |
+    v1.1.8：下载架构改造——用共享的 llm-init download-only 部署（镜像 llm-init:v1.2.4，
+    默认 LFS）替换原自研下载器。模型改为落入跨应用共享 HF 缓存（App Common），OCR 引擎
+    改为等待下载器 /readyz（替代 .done sentinel），/app/models 改为指向缓存快照的符号链接。
+    声明 permission.appCommon: true，并将 nvidia-gb10 limitedMemory 提到 28Gi 以容纳下载器更大的内存上限。
+
     迁移 DeepSeek-OCR-2 WebUI 至 apiVersion v3 共享应用模式（deepseekocrwebuiv2 → deepseekocrwebuiv3）。
 
     **更新内容**

--- a/deepseekocrwebuiv3/templates/clientproxy.yaml
+++ b/deepseekocrwebuiv3/templates/clientproxy.yaml
@@ -6,69 +6,123 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   nginx.conf: |
-{{- `
-    upstream app_backend {
-      server deepseekocrwebuiv3-svc:8001 max_fails=1 fail_timeout=2s;
-      server download-svc:8090 backup;
-    }
-
+    # DeepSeek-OCR entrance: gate the OCR WebUI on model download (llm-init
+    # /readyz) AND app readiness (OCR service answering on :8001). While gated,
+    # serve the llm-init download dashboard; llm-init API paths (/api/progress,
+    # /healthz, …) are pinned to download-svc so they never fall through to the
+    # OCR app (404). The dashboard auto-reloads into the app once /__app_ready
+    # flips to 200.
     server {
-      listen 8080;
-      access_log /opt/bitnami/openresty/nginx/logs/access.log;
-      error_log /opt/bitnami/openresty/nginx/logs/error.log;
+        listen 8080;
+        access_log /opt/bitnami/openresty/nginx/logs/access.log;
+        error_log /opt/bitnami/openresty/nginx/logs/error.log;
 
-      location /gradio_api/info {
-        proxy_pass http://deepseekocrwebuiv3-svc:8001;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-Host $http_host;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-
-        proxy_hide_header Access-Control-Allow-Origin;
-        proxy_hide_header Access-Control-Allow-Methods;
-        proxy_hide_header Access-Control-Allow-Headers;
-        add_header Access-Control-Allow-Origin *;
-        add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS, HEAD";
-        add_header Access-Control-Allow-Headers "deviceType,token,authorization,content-type,x-csrftoken";
-
-        if ($request_method = 'OPTIONS') {
-          add_header Access-Control-Allow-Origin *;
-          add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS, HEAD";
-          add_header Access-Control-Allow-Headers "deviceType,token,authorization,content-type,x-csrftoken";
-          return 204;
-        }
-      }
-
-      location / {
-        proxy_pass http://app_backend;
-        proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
-        proxy_connect_timeout 600s;
-        proxy_read_timeout 600s;
+        client_max_body_size 500m;
+        proxy_buffering off;
+        proxy_redirect off;
+        proxy_connect_timeout 60s;
         proxy_send_timeout 1800s;
-
-        proxy_http_version 1.1;
+        proxy_read_timeout 600s;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
 
-        proxy_hide_header Access-Control-Allow-Origin;
-        proxy_hide_header Access-Control-Allow-Methods;
-        proxy_hide_header Access-Control-Allow-Headers;
-        add_header Access-Control-Allow-Origin *;
-        add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS, HEAD";
-        add_header Access-Control-Allow-Headers "deviceType,token,authorization,content-type,x-csrftoken";
+        resolver coredns.kube-system.svc.cluster.local valid=10s;
 
-        if ($request_method = 'OPTIONS') {
-          add_header Access-Control-Allow-Origin *;
-          add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS, HEAD";
-          add_header Access-Control-Allow-Headers "deviceType,token,authorization,content-type,x-csrftoken";
-          return 204;
+        # llm-init control-plane API — always reach the downloader, not the app.
+        location /api/ {
+            proxy_pass http://download-svc.{{ .Release.Namespace }}.svc.cluster.local:8090;
         }
-      }
+        location /static/ {
+            proxy_pass http://download-svc.{{ .Release.Namespace }}.svc.cluster.local:8090;
+        }
+        location = /healthz {
+            proxy_pass http://download-svc.{{ .Release.Namespace }}.svc.cluster.local:8090/healthz;
+        }
+        location = /livez {
+            proxy_pass http://download-svc.{{ .Release.Namespace }}.svc.cluster.local:8090/livez;
+        }
+        location = /readyz {
+            proxy_pass http://download-svc.{{ .Release.Namespace }}.svc.cluster.local:8090/readyz;
+        }
+        # Legacy progress path → llm-init progress snapshot.
+        location = /progress {
+            proxy_pass http://download-svc.{{ .Release.Namespace }}.svc.cluster.local:8090/api/progress;
+        }
+
+        # Internal gates for auth_request / auto-reload polling.
+        location = /__models_ready {
+            internal;
+            proxy_pass http://download-svc.{{ .Release.Namespace }}.svc.cluster.local:8090/readyz;
+            proxy_pass_request_body off;
+            proxy_set_header Content-Length "";
+            proxy_connect_timeout 3s;
+            proxy_read_timeout 5s;
+            proxy_send_timeout 5s;
+        }
+        location = /__main_ready {
+            internal;
+            proxy_pass http://deepseekocrwebuiv3-svc.{{ .Release.Namespace }}.svc.cluster.local:8001/;
+            proxy_pass_request_body off;
+            proxy_set_header Content-Length "";
+            proxy_connect_timeout 3s;
+            proxy_read_timeout 5s;
+            proxy_send_timeout 5s;
+        }
+        # Public: 200 once the model is on disk AND the OCR app is answering.
+        location = /__app_ready {
+            default_type text/plain;
+            content_by_lua_block {
+                local models = ngx.location.capture("/__models_ready")
+                if models.status ~= 200 then
+                    ngx.status = 503
+                    return
+                end
+                local main = ngx.location.capture("/__main_ready")
+                if main.status < 200 or main.status >= 500 then
+                    ngx.status = 503
+                    return
+                end
+                ngx.status = 200
+                ngx.say("ok")
+            }
+        }
+
+        location / {
+            auth_request /__models_ready;
+            error_page 401 403 500 502 503 504 = @downloader;
+            proxy_pass http://deepseekocrwebuiv3-svc.{{ .Release.Namespace }}.svc.cluster.local:8001;
+            proxy_hide_header Access-Control-Allow-Origin;
+            proxy_hide_header Access-Control-Allow-Methods;
+            proxy_hide_header Access-Control-Allow-Headers;
+            add_header Access-Control-Allow-Origin *;
+            add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS, HEAD";
+            add_header Access-Control-Allow-Headers "deviceType,token,authorization,content-type,x-csrftoken";
+            if ($request_method = 'OPTIONS') {
+              add_header Access-Control-Allow-Origin *;
+              add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS, HEAD";
+              add_header Access-Control-Allow-Headers "deviceType,token,authorization,content-type,x-csrftoken";
+              return 204;
+            }
+        }
+
+        # llm-init download dashboard + auto-reload once /__app_ready flips 200.
+        location @downloader {
+            proxy_pass http://download-svc.{{ .Release.Namespace }}.svc.cluster.local:8090;
+            proxy_set_header Accept-Encoding "";
+            sub_filter_once on;
+            sub_filter_types text/html;
+            sub_filter '</body>' '<script>(function(){function c(){fetch("/__app_ready",{cache:"no-store"}).then(function(r){if(r.ok){location.reload();}}).catch(function(){});}setInterval(c,3000);})();</script></body>';
+            proxy_connect_timeout 10s;
+            proxy_read_timeout 120s;
+            proxy_send_timeout 120s;
+        }
     }
-` | nindent 4 }}
 
 ---
 apiVersion: apps/v1
@@ -99,7 +153,7 @@ spec:
                 path: nginx.conf
       containers:
         - name: nginx
-          image: "docker.io/aboveos/bitnami-openresty:1.25.3-2"
+          image: "docker.io/beclab/aboveos-bitnami-openresty:1.25.3-2"
           ports:
             - containerPort: 8080
               protocol: TCP

--- a/deepseekocrwebuiv3/templates/deployment.yaml
+++ b/deepseekocrwebuiv3/templates/deployment.yaml
@@ -16,7 +16,8 @@
 {{- if $unifiedMem -}}
 {{- /* GPU (up to gpumem == requiredMemory 16Gi) is carved from pod RAM. Keep
        sums within the nvidia-gb10 accelerator envelope: requests <= 16Gi
-       requiredMemory, limits <= 25Gi limitedMemory (download 1Gi + nginx 0.5Gi). */ -}}
+       requiredMemory, limits <= 28Gi limitedMemory (llm-init download 4Gi +
+       nginx 0.5Gi). */ -}}
 {{- $memRequest = "13Gi" -}}
 {{- $memLimit = "23Gi" -}}
 {{- end -}}
@@ -49,13 +50,46 @@ spec:
             - /bin/bash
             - -c
             - |
-              DONE_FILE="{{ $modelPath }}{{ "/.DeepSeek-OCR-2.done" }}"
-              echo "[ocr-wait] Waiting for model download: $DONE_FILE ..."
-              while [ ! -f "$DONE_FILE" ]; do
-                echo "[ocr-wait] Model not ready, sleeping..."
+              set -e
+              CACHE=/cache/hf/hub
+              READYZ="http://download-svc.{{ .Release.Namespace }}.svc.cluster.local:8090/readyz"
+
+              # Gate on the llm-init downloader (download-only mode) reporting the
+              # repo present. /readyz flips to 200 only once every MODEL_SOURCE repo
+              # is fully on disk, replacing the old .DeepSeek-OCR-2.done sentinel.
+              echo "[ocr-wait] Waiting for llm-init downloader (/readyz)..."
+              until python - "$READYZ" <<'RDY_EOF' 2>/dev/null
+              import sys, urllib.request
+              try:
+                  with urllib.request.urlopen(sys.argv[1], timeout=5) as r:
+                      sys.exit(0 if r.status == 200 else 1)
+              except Exception:
+                  sys.exit(1)
+              RDY_EOF
+              do
+                echo "[ocr-wait] downloader not ready yet..."
                 sleep 10
               done
-              echo "[ocr-wait] Model ready, starting OCR service."
+              echo "[ocr-wait] downloader ready; materialising {{ $modelPath }} from HF cache."
+
+              # llm-init writes the standard HF cache snapshot layout
+              # ($CACHE/models--deepseek-ai--DeepSeek-OCR-2/snapshots/<sha>/...), but
+              # the OCR service loads a flat LOCAL_MODEL_PATH. Rebuild that flat view
+              # as a symlink farm pointing at the resolved snapshot. The snapshot's
+              # internal blob symlinks are relative to $CACHE (mounted here at the
+              # same path), so they resolve transparently.
+              REPO_DIR="$CACHE/models--deepseek-ai--DeepSeek-OCR-2"
+              if [ -f "$REPO_DIR/refs/main" ]; then
+                SNAP="$REPO_DIR/snapshots/$(cat "$REPO_DIR/refs/main")"
+              else
+                SNAP="$(ls -d "$REPO_DIR"/snapshots/*/ 2>/dev/null | head -1)"
+              fi
+              mkdir -p {{ $modelPath }}
+              for f in "$SNAP"/* "$SNAP"/.[!.]*; do
+                [ -e "$f" ] || continue
+                ln -sfn "$f" "{{ $modelPath }}/$(basename "$f")"
+              done
+              echo "[ocr-wait] model ready, starting OCR service."
               python web_service_unified.py
           ports:
             - containerPort: 8001
@@ -92,12 +126,20 @@ spec:
           volumeMounts:
             - name: models
               mountPath: {{ $modelPath }}
+            # Shared cross-app HF Hub cache (App Common), populated by the
+            # llm-init downloader. Read here to build the model symlink farm.
+            - name: hf-cache
+              mountPath: /cache/hf/hub
             - name: logs
               mountPath: /app/log
       volumes:
+        # {{ $modelPath }} is now an ephemeral symlink farm rebuilt on every start;
+        # the real model bytes persist in the shared HF cache below.
         - name: models
+          emptyDir: {}
+        - name: hf-cache
           hostPath:
-            path: "{{ .Values.userspace.userData }}/Huggingface/{{ .Release.Name }}"
+            path: "{{ .Values.userspace.appCommon }}/huggingface"
             type: DirectoryOrCreate
         - name: logs
           hostPath:

--- a/deepseekocrwebuiv3/templates/download.yaml
+++ b/deepseekocrwebuiv3/templates/download.yaml
@@ -1,3 +1,14 @@
+{{- /* llm-init in download-only mode (ENGINE_KIND empty): no engine is started
+       or proxied; llm-init degrades to a pure model downloader that drops the
+       DeepSeek-OCR-2 repo into the shared cross-app HF Hub cache (App Common,
+       fixed /cache/hf/hub). The OCR engine mounts the same store and waits on
+       /readyz before materialising the flat /app/models layout it expects
+       (see deployment.yaml). This replaces the bespoke harveyff-hf-downloader. */ -}}
+{{- $oe := .Values.olaresEnv | default dict -}}
+{{- $hfToken := $oe.HF_TOKEN | default "" -}}
+{{- /* Per-release run-state hostPath so concurrent clones on the same node do
+       not collide on the sentinel. */ -}}
+{{- $runStateHostPath := printf "%s/llm-init-run/%s" .Values.userspace.appCache .Release.Name -}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -18,73 +29,109 @@ spec:
       labels:
         app: deepseekocrwebuiv3download
     spec:
+      restartPolicy: Always
+      volumes:
+        # Shared cross-app HF Hub cache (App Common); image bakes HF_HUB_CACHE=/cache/hf/hub.
+        - name: hf-cache
+          hostPath:
+            path: "{{ .Values.userspace.appCommon }}/huggingface"
+            type: DirectoryOrCreate
+        # Per-release sentinel / run-state dir (App Cache).
+        - name: run-state
+          hostPath:
+            path: "{{ $runStateHostPath }}"
+            type: DirectoryOrCreate
+      initContainers:
+        # hostPath dirs are created root-owned; llm-init runs as UID 1000.
+        - name: init-chown
+          image: docker.io/beclab/aboveos-busybox:1.37.0
+          command:
+            - sh
+            - -c
+            - "chown 1000:1000 /cache/hf/hub /run/llm-init || true"
+          volumeMounts:
+            - name: hf-cache
+              mountPath: /cache/hf/hub
+            - name: run-state
+              mountPath: /run/llm-init
+          securityContext:
+            runAsUser: 0
       containers:
-        - name: download-model
-          image: "docker.io/beclab/harveyff-hf-downloader-only:v0.0.6"
+        - name: llm-init
+          # v1.2.4: nullengine download-only, default LFS (hf_xet off unless
+          # HF_ENABLE_XET=true) for stable download memory.
+          image: docker.io/beclab/llm-init:v1.2.4
+          imagePullPolicy: IfNotPresent
           env:
-            - name: HF_ENDPOINT
-              value: "{{ if .Values.olaresEnv }}{{ .Values.olaresEnv.HF_ENDPOINT | default "" }}{{ end }}"
-            - name: HF_TOKEN
-              value: "{{ if .Values.olaresEnv }}{{ .Values.olaresEnv.HF_TOKEN | default "" }}{{ end }}"
+            # Empty ENGINE_KIND selects download-only mode (nullengine).
+            - name: ENGINE_KIND
+              value: ""
+            # TEMPORARY (llm-init v1.2.4 image): download-only still requires
+            # MODEL_NAME + MODEL_MODE. They are placeholders only — the repo to
+            # fetch comes entirely from MODEL_SOURCE. Drop both once the
+            # make-optional patch ships.
             - name: MODEL_NAME
-              value: "DeepSeek-OCR-2"
-          args:
-            - "--repo"
-            - "deepseek-ai/DeepSeek-OCR-2"
-            - "--ref"
-            - "main"
-            - "--outdir"
-            - "/data"
-            - "--static"
-            - "/app/static"
-            - "--port"
-            - "8090"
-            - "--probe-url"
-            - "/health"
-            - "--done-name"
-            - ".DeepSeek-OCR-2.done"
-          startupProbe:
-            httpGet:
-              path: /ping
-              port: 8090
-            initialDelaySeconds: 5
-            timeoutSeconds: 10
-            periodSeconds: 10
-            failureThreshold: 10
+              value: "deepseek-ai/DeepSeek-OCR-2"
+            - name: MODEL_MODE
+              value: "chat"
+            # Single full repo (no --include); must be hf://.
+            - name: MODEL_SOURCE
+              value: "hf://deepseek-ai/DeepSeek-OCR-2"
+            # Always wire the Olares HF mirror (manifest requires HF_ENDPOINT).
+            - name: HF_ENDPOINT
+              value: "{{ $oe.HF_ENDPOINT }}"
+{{- if $hfToken }}
+            - name: HF_TOKEN
+              value: "{{ $hfToken }}"
+{{- end }}
+            # Keep concurrency low; LFS is the image default in v1.2.4.
+            - name: MAX_CONCURRENT_DOWNLOADS
+              value: "1"
+            - name: RUN_DIR
+              value: /run/llm-init
+            - name: PORT
+              value: "8090"
+            - name: LOG_FORMAT
+              value: json
+          ports:
+            - name: http
+              containerPort: 8090
           livenessProbe:
             httpGet:
-              path: /ping
+              path: /livez
               port: 8090
-              scheme: HTTP
-            initialDelaySeconds: 10
-            timeoutSeconds: 60
-            periodSeconds: 60
-            successThreshold: 1
-            failureThreshold: 10
-          ports:
-            - containerPort: 8090
-              name: http
+            periodSeconds: 30
+            timeoutSeconds: 5
+          # Readiness on /livez (process up), not /readyz (model ready), so the
+          # downloader stays scheduled and serving progress while downloading.
+          readinessProbe:
+            httpGet:
+              path: /livez
+              port: 8090
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
           volumeMounts:
-            - name: models
-              mountPath: /data
+            - name: hf-cache
+              mountPath: /cache/hf/hub
+            - name: run-state
+              mountPath: /run/llm-init
           resources:
             requests:
-              cpu: "100m"
-              memory: "500Mi"
+              cpu: 100m
+              memory: 128Mi
             limits:
-              cpu: "1"
-              memory: 1Gi
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
-          imagePullPolicy: IfNotPresent
-      volumes:
-        - name: models
-          hostPath:
-            path: "{{ .Values.userspace.userData }}/Huggingface/{{ .Release.Name }}"
-            type: DirectoryOrCreate
-      restartPolicy: Always
+              cpu: 500m
+              # `hf download` runs a python subprocess in this cgroup; 4Gi gives
+              # the huggingface_hub CLI headroom on multi-GB model downloads.
+              memory: 4Gi
 
 ---
+# Internal progress / health surface (no entrance). The OCR engine waits on
+# /readyz here before reading the shared cache; the nginx clientproxy uses this
+# Service as the backup upstream so the download dashboard shows until the app
+# comes up.
 apiVersion: v1
 kind: Service
 metadata:
@@ -93,9 +140,10 @@ metadata:
   labels:
     app: deepseekocrwebuiv3download
 spec:
+  selector:
+    app: deepseekocrwebuiv3download
   ports:
     - name: http
       port: 8090
       targetPort: 8090
-  selector:
-    app: deepseekocrwebuiv3download
+  type: ClusterIP


### PR DESCRIPTION
…d HF cache)

Replace the bespoke harveyff-hf-downloader with the shared llm-init download-only Deployment (image llm-init:v1.2.4, default LFS), matching acestep15v3/speachesv3. The DeepSeek-OCR-2 model now lands in the shared cross-app HF cache (App Common, /cache/hf/hub) and is de-duplicated across apps; the OCR engine gates on the downloader's /readyz instead of the .DeepSeek-OCR-2.done sentinel and materialises /app/models as a symlink farm over the cached snapshot.

- download.yaml: llm-init download-only Deployment + run-state hostPath
- deployment.yaml: hf-cache mount, /readyz gate + symlink farm, models -> emptyDir
- clientproxy.yaml: rewrote nginx to the llm-init dashboard pattern (pin API paths to download-svc; / gates on download + app readiness and auto-reloads via /__app_ready); openresty image with lua
- OlaresManifest: permission.appCommon: true, version 1.1.7 -> 1.1.8, nvidia-gb10 limitedMemory 25Gi -> 28Gi, upgradeDescription; i18n synced

### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
> The title of your application appears on Market.

### Description
> Brief description about your application here. 
>
> For app updates, please describe the changes.

### Statement
- [ ] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
