### PR TITLE
[UPDATE][hermesagent][1.3.15] upgrade Hermes to v0.16.0 and switch to pre-baked UID 1000 image

### DIFF
--- a/hermesagent/Chart.yaml
+++ b/hermesagent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: '0.15.2'
+appVersion: '0.16.0'
 description: The self-improving AI agent built by Nous Research
 name: hermesagent
 type: application
-version: 1.3.14
+version: 1.3.15

--- a/hermesagent/Dockerfile
+++ b/hermesagent/Dockerfile
@@ -1,0 +1,65 @@
+# syntax=docker/dockerfile:1
+# ---------------------------------------------------------------------------
+# Thin overlay on the official Hermes Agent image.
+#
+# Purpose: remap the baked `hermes` user/group to UID/GID 1000 so the runtime
+# identity matches Olares user-data ownership (appData + Home/External host
+# mounts are owned 1000:1000).
+#
+# Why re-bake instead of just setting HERMES_UID=1000 at runtime:
+#   Upstream bakes hermes at UID 10000 and owns the build trees
+#   (/opt/hermes/.venv, ui-tui, gateway, node_modules — ~47k files) as 10000.
+#   Running as 1000 makes the s6 stage2 hook chown all of them on EVERY boot;
+#   on overlayfs that forces a full per-file copy-up and the container hangs
+#   during cont-init. Re-owning to 1000 in this layer makes stage2's
+#   `venv_owner != hermes_uid` probe false, so its chown is skipped (no runtime
+#   copy-up) and the process can write Olares' 1000-owned mounts.
+#
+# Trade-off: the chown below copies the re-owned files into this new image
+# layer, so the result is larger than upstream by ~the size of the build trees.
+# Boot is fast; image pull/disk is bigger.
+#
+# Build (all args optional; defaults shown):
+#   docker buildx build \
+#     --build-arg HERMES_VERSION=v2026.6.5 \
+#     --build-arg TARGET_UID=1000 \
+#     --build-arg TARGET_GID=1000 \
+#     --platform linux/amd64 \
+#     -t harveyff/hermes-agent:v2026.6.5-uid1000 --push .
+#
+# Upgrades: just pass a newer --build-arg HERMES_VERSION and rebuild.
+# ---------------------------------------------------------------------------
+
+# Global ARG consumed by FROM. Must be declared before the first FROM.
+ARG HERMES_VERSION=v2026.6.5
+FROM nousresearch/hermes-agent:${HERMES_VERSION}
+
+# Re-declare after FROM to make these usable inside RUN below.
+ARG TARGET_UID=1000
+ARG TARGET_GID=1000
+
+USER root
+
+RUN set -eu; \
+    # Capture the upstream-baked UID/GID instead of hardcoding 10000, so the
+    # sweep still works if upstream ever changes its default.
+    OLD_UID="$(id -u hermes)"; \
+    OLD_GID="$(id -g hermes)"; \
+    if [ "$OLD_UID" != "$TARGET_UID" ] || [ "$OLD_GID" != "$TARGET_GID" ]; then \
+        groupmod -g "$TARGET_GID" hermes; \
+        usermod -u "$TARGET_UID" -g "$TARGET_GID" hermes; \
+        # usermod -u only re-owns the home dir; re-own everything the upstream
+        # build left at the old UID/GID under the install dir in one sweep.
+        # (/opt/data is a runtime hostPath mount + declared VOLUME, so skip it.)
+        # -h so symlinks themselves are re-owned (chown without -h dereferences
+        # and would leave the link node still owned by the old UID, e.g.
+        # node_modules/.bin/* shims). It behaves as a normal chown on real files.
+        find /opt/hermes -xdev \( -uid "$OLD_UID" -o -gid "$OLD_GID" \) \
+            -exec chown -h "$TARGET_UID:$TARGET_GID" {} +; \
+        # Fail the build if anything is still owned by the old identity.
+        remaining="$(find /opt/hermes -xdev \( -uid "$OLD_UID" -o -gid "$OLD_GID" \) | head -n1)"; \
+        [ -z "$remaining" ] || { echo "ERROR: still owned by $OLD_UID:$OLD_GID: $remaining"; exit 1; }; \
+    fi
+
+# Identity (now TARGET_UID:TARGET_GID), ENTRYPOINT (/init + main-wrapper) and
+# CMD are inherited from the base image — no other behavior changes.

--- a/hermesagent/OlaresManifest.yaml
+++ b/hermesagent/OlaresManifest.yaml
@@ -6,7 +6,7 @@ metadata:
   description: The agent that grows with you
   appid: hermesagent
   title: Hermes Agent
-  version: 1.3.14
+  version: 1.3.15
   categories:
   - Productivity_v112
   - Developer Tools
@@ -33,7 +33,7 @@ entrances:
   invisible: true
   authLevel: internal
 spec:
-  versionName: '0.15.2'
+  versionName: '0.16.0'
   fullDescription: |
     **The self-improving AI agent built by [Nous Research](https://nousresearch.com).** It's the only agent with a built-in learning loop — it creates skills from experience, improves them during use, nudges itself to persist knowledge, searches its own past conversations, and builds a deepening model of who you are across sessions. Run it on a $5 VPS, a GPU cluster, or serverless infrastructure that costs nearly nothing when idle. It's not tied to your laptop — talk to it from Telegram while it works on a cloud VM.
 
@@ -62,11 +62,12 @@ spec:
     - Localized into 7 languages (中文 / 日本語 / Deutsch / Español / Français / Українська / Türkçe) plus a Chinese dashboard.
 
   upgradeDescription: |
-    Config changes: Change HERMUES_UID 1000:1000
+    Image change: switch to a pre-baked UID 1000:1000 image (beclab/harveyff-hermes-agent:v2026.6.5-uid1000, Hermes v0.16.0).
     
     Change Details: 
-    - Align Hermes runtime identity to Olares UID 1000:1000 (replacing 10000), with automatic ownership migration on upgrade.
-    - Fix Terminal and Dashboard access: unified shell privilege drop for interactive sessions, persistent brew PATH, and Home/External volume mounts on the dashboard container.
+    - Run as UID/GID 1000:1000 baked into the image instead of remapping at boot via HERMES_UID, removing the slow ownership rewrite that could hang the container on startup. Installs and upgrades match Olares userData ownership directly.
+    - Drop obsolete startup workarounds now fixed upstream in v0.16.0: dashboard WebSocket loopback patch, olares-cli permission repair, and the removed `--tui` dashboard flag.
+    - Harden the gateway container with seccomp RuntimeDefault and a minimal Linux capability set.
 
   developer: Nous Research
   website: https://hermes-agent.nousresearch.com

--- a/hermesagent/i18n/en-US/OlaresManifest.yaml
+++ b/hermesagent/i18n/en-US/OlaresManifest.yaml
@@ -30,8 +30,9 @@ spec:
     - Localized into 7 languages (中文 / 日本語 / Deutsch / Español / Français / Українська / Türkçe) plus a Chinese dashboard.
 
   upgradeDescription: |
-    Config changes: Change HERMUES_UID 1000:1000
+    Image change: switch to a pre-baked UID 1000:1000 image (beclab/harveyff-hermes-agent:v2026.6.5-uid1000, Hermes v0.16.0).
     
     Change Details: 
-    - Align Hermes runtime identity to Olares UID 1000:1000 (replacing 10000), with automatic ownership migration on upgrade.
-    - Fix Terminal and Dashboard access: unified shell privilege drop for interactive sessions, persistent brew PATH, and Home/External volume mounts on the dashboard container.
+    - Run as UID/GID 1000:1000 baked into the image instead of remapping at boot via HERMES_UID, removing the slow ownership rewrite that could hang the container on startup. Installs and upgrades match Olares userData ownership directly.
+    - Drop obsolete startup workarounds now fixed upstream in v0.16.0: dashboard WebSocket loopback patch, olares-cli permission repair, and the removed `--tui` dashboard flag.
+    - Harden the gateway container with seccomp RuntimeDefault and a minimal Linux capability set.

--- a/hermesagent/i18n/zh-CN/OlaresManifest.yaml
+++ b/hermesagent/i18n/zh-CN/OlaresManifest.yaml
@@ -30,8 +30,9 @@ spec:
     - 已本地化为 7 种语言（中文 / 日本語 / Deutsch / Español / Français / Українська / Türkçe），Dashboard 已支持中文。
 
   upgradeDescription: |
-    配置变更：将 HERMES_UID 更改为 1000:1000
+    镜像变更：改用预置 UID 1000:1000 的镜像（beclab/harveyff-hermes-agent:v2026.6.5-uid1000，Hermes v0.16.0）。
 
     具体变更说明：
-    - 统一 Hermes 运行身份为 Olares 平台的 UID 1000:1000（由原 10000 替换），升级时自动迁移已有文件属主。
-    - 修复终端和 Dashboard 访问：统一交互式会话降权方案，brew 路径永久有效，Dashboard 容器支持 Home/External 卷挂载。
+    - 直接以镜像内置的 UID/GID 1000:1000 运行，不再通过 HERMES_UID 在启动时重映射身份，从而去掉了可能导致容器启动卡死的属主重写过程；全新安装与升级都直接匹配 Olares userData 的属主。
+    - 移除已被上游 v0.16.0 修复的临时绕过逻辑：Dashboard WebSocket loopback 补丁、olares-cli 权限修复，以及已被上游删除的 `--tui` 参数。
+    - 为 gateway 容器加固：启用 seccomp RuntimeDefault 与最小化 Linux capabilities。

--- a/hermesagent/templates/deployment.yaml
+++ b/hermesagent/templates/deployment.yaml
@@ -1,14 +1,11 @@
-# Hermes Agent on Olares. 3 runtime containers (gateway / dashboard /
-# hermesagent workspace) + init containers, all sharing /opt/data (hostPath)
-# as the single source of truth (SQLite, config, .env, skills, memories).
-#
-# The s6-overlay v3 image (/init as PID 1) MUST start as root: s6 chowns /run +
-# /opt/data and drops every service to the hermes user via s6-setuidgid.
-# Pinning runAsUser breaks that drop (setgroups EPERM), so we start as root
-# and pass HERMES_UID/HERMES_GID=1000 to match Olares userData ownership.
-# `kubectl exec` attaches as root; interactive shells source drop-to-hermes
-# (profile.d + $HOME/.bashrc) to re-exec as hermes (uid 1000). The hermes
-# CLI shim at /opt/hermes/bin/hermes does the same for non-interactive calls.
+# 3 runtime containers (gateway / dashboard / workspace) + init containers
+# share /opt/data (hostPath). The s6-overlay v3 image MUST start as root (s6
+# chowns /run + /opt/data, then s6-setuidgid-drops to hermes); pinning
+# runAsUser breaks that drop, so we start root and let s6 drop to hermes.
+# The custom image bakes hermes at UID/GID 1000 (= Olares user-data owner),
+# so no HERMES_UID/GID override is needed: stage2's build-tree chown is a
+# no-op (no overlayfs copy-up on boot) and the runtime identity (1000) can
+# write the Olares user-data mounts.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -30,9 +27,7 @@ spec:
         io.kompose.service: hermesagent
         bytetrade.io/terminal: hermesagent
     spec:
-      # Start as root so s6 can drop services to uid 1000 itself; do NOT set
-      # runAsUser (breaks s6's privilege drop). fsGroup keeps volumes group-
-      # accessible to 1000 (Olares platform default).
+      # Do NOT set runAsUser (breaks s6's drop); fsGroup keeps volumes at gid 1000.
       securityContext:
         fsGroup: 1000
 
@@ -81,8 +76,7 @@ spec:
             - mountPath: /opt/data
               name: app-data-home
 
-        # Materialize Linuxbrew + olares-cli + CLI shims onto the brew-volume
-        # hostPath. Idempotent on .brew-base-build.
+        # Materialize Linuxbrew + olares-cli + CLI shims onto the brew-volume.
         - name: init-install-brew
           image: "beclab/harveyff-openclaw-brew-base:2026.5.29-cli"
           imagePullPolicy: IfNotPresent
@@ -105,46 +99,7 @@ spec:
                 cp -a /brew-staging/.linuxbrew/. /home/linuxbrew/.linuxbrew/
               fi
 
-              # Stage olares-cli into the persistent brew-volume bin dir.
-              OLARES_CLI=""
-              for p in /usr/local/bin/olares-cli \
-                         /brew-staging/.linuxbrew/bin/olares-cli \
-                         /brew-staging/olares-cli \
-                         /opt/olares-cli/olares-cli \
-                         /olares-cli; do
-                [ -x "$p" ] && OLARES_CLI="$p" && break
-              done
-              if [ -z "$OLARES_CLI" ]; then
-                OLARES_CLI="$(find /brew-staging /usr/local /opt -maxdepth 8 -type f \
-                  \( -name 'olares-cli' -o -name 'olares-cli-*' \) -perm -u+x 2>/dev/null | head -1)"
-              fi
-              if [ -z "$OLARES_CLI" ] && command -v curl >/dev/null 2>&1; then
-                case "$(uname -m)" in
-                  x86_64|amd64)
-                    OLARES_CLI_URL="https://cdn.olares.com/olares-cli-v1.12.7-20260510_linux_amd64.8705e94.tar.gz"
-                    ;;
-                  aarch64|arm64)
-                    OLARES_CLI_URL="https://cdn.olares.com/olares-cli-v1.12.7-20260510_linux_arm64.8705e94.tar.gz"
-                    ;;
-                esac
-                if [ -n "${OLARES_CLI_URL:-}" ]; then
-                  echo "[init-brew] fetching olares-cli from CDN (${OLARES_CLI_URL})..."
-                  mkdir -p /tmp/olares-cli-extract
-                  if curl -fsSL -o /tmp/olares-cli.tgz "$OLARES_CLI_URL"; then
-                    tar -xzf /tmp/olares-cli.tgz -C /tmp/olares-cli-extract
-                    OLARES_CLI="$(find /tmp/olares-cli-extract -maxdepth 4 -type f \
-                      \( -name 'olares-cli' -o -name 'olares-cli-*' \) -perm -u+x 2>/dev/null | head -1)"
-                  fi
-                fi
-              fi
-              if [ -n "$OLARES_CLI" ]; then
-                mkdir -p /home/linuxbrew/.linuxbrew/bin
-                install -m 0755 "$OLARES_CLI" /home/linuxbrew/.linuxbrew/bin/olares-cli
-                rm -f /home/linuxbrew/.linuxbrew/bin/olares-cli.real
-                echo "[init-brew] olares-cli staged to /home/linuxbrew/.linuxbrew/bin from $OLARES_CLI"
-              else
-                echo "[init-brew] WARN: olares-cli not found (image + CDN)"
-              fi
+              # olares-cli ships in the brew base and arrives via the cp above.
 
               # python3 shim -> hermes venv.
               printf '#!/bin/sh\nexec /opt/hermes/.venv/bin/python3 "$@"\n' > /cli-bin/python3
@@ -154,26 +109,11 @@ spec:
               printf '#!/bin/sh\nset -eu\nS="${HERMES_GATEWAY_RESTART_SENTINEL:-/opt/data/.gateway-restart-requested}"\ntouch "$S"\necho "[restart-gateway] sentinel touched at $S, waiting ~6s for gateway to come back..."\nsleep 6\necho "[restart-gateway] done"\n' > /cli-bin/restart-gateway
               chmod 0755 /cli-bin/restart-gateway
 
-              # Neutralize the image's 02-reconcile-profiles cont-init: it starts a
-              # per-profile gateway s6 logger that deadlocks on the shared /opt/data
-              # log lock across containers. The gateway runs via its CMD wrapper.
+              # Neutralize 02-reconcile-profiles: its per-profile s6 logger
+              # deadlocks on the shared /opt/data log lock across containers.
               printf '#!/bin/sh\nexit 0\n' > /cli-bin/02-reconcile-profiles
               chmod 0755 /cli-bin/02-reconcile-profiles
-
-              # WORKAROUND (remove once a fixed image ships): dashboard WS endpoints
-              # only accept a loopback peer in --insecure mode, breaking the web TUI
-              # behind the Olares ingress. Auth is handled by Olares SSO, so relax
-              # that peer check at boot. Upstream: NousResearch/hermes-agent #34396.
-              printf '#!/bin/sh\nF=/opt/hermes/hermes_cli/web_server.py\n[ -f "$F" ] && sed -i "s/return client_host in _LOOPBACK_HOSTS/return True/" "$F"\nexit 0\n' > /cli-bin/03-allow-dashboard-ws
-              chmod 0755 /cli-bin/03-allow-dashboard-ws
-
-              # Repair olares-cli state after legacy root kubectl exec writes.
-              printf '#!/bin/sh\nD="/opt/data/.olares-cli"\nmkdir -p "$D/data" 2>/dev/null || true\nchown -R 1000:1000 "$D" 2>/dev/null || true\nchmod -R u+rwX,g+rwX "$D" 2>/dev/null || true\nexit 0\n' \
-                > /cli-bin/04-fix-olares-cli-perms
-              chmod 0755 /cli-bin/04-fix-olares-cli-perms
-
-              # Interactive kubectl exec drops root → hermes (uid 1000) once per session.
-              # Mounted on the hermesagent container only; $HOME/.bashrc sources it too.
+              # drop-to-hermes: interactive root kubectl exec re-execs as hermes (1000).
               printf '%s\n' \
                 '#!/bin/sh' \
                 '# Olares: drop interactive root shells to hermes (UID 1000).' \
@@ -236,14 +176,10 @@ spec:
               name: app-data-home
 
       containers:
-        # Gateway sidecar: messaging gateway + (optional) OpenAI-compat API.
-        # Wrapper loop auto-restarts `hermes gateway run` (it exits clean with no
-        # tokens) so setup/.env edits get picked up. It also polls a sentinel
-        # (/opt/data/.gateway-restart-requested) so a TUI `gateway restart` in
-        # another container can trigger a restart. No port is bound by default,
-        # so probes check the data dir instead.
+        # Gateway sidecar. Wrapper loop auto-restarts `hermes gateway run` and
+        # polls a sentinel so a TUI `gateway restart` elsewhere triggers a restart.
         - name: gateway
-          image: "beclab/nousresearch-hermes-agent:v2026.5.29.2"
+          image: "beclab/harveyff-hermes-agent:v2026.6.5-uid1000"
           imagePullPolicy: IfNotPresent
           args:
             - "/bin/bash"
@@ -370,14 +306,8 @@ spec:
               containerPort: 8642
               protocol: TCP
           env:
-            # HOME on /opt/data so HOME-respecting CLIs persist + share config.
             - name: HOME
               value: /opt/data
-            # uid/gid s6 maps the hermes user to (Olares platform default 1000).
-            - name: HERMES_UID
-              value: "1000"
-            - name: HERMES_GID
-              value: "1000"
             - name: HERMES_HOME
               value: /opt/data
             - name: HERMES_GATEWAY_RESTART_DELAY_SECONDS
@@ -394,7 +324,6 @@ spec:
               value: "1"
             - name: PATH
               value: "/opt/hermes/bin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/opt/hermes/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-            # Absolute olares-cli paths (hermes rewrites HOME for subprocesses).
             - name: OLARES_CLI_HOME
               value: /opt/data/.olares-cli
             - name: OLARES_CLI_DATA_DIR
@@ -447,10 +376,6 @@ spec:
               name: cli-bin
               subPath: 02-reconcile-profiles
               readOnly: true
-            - mountPath: /etc/cont-init.d/04-fix-olares-cli-perms
-              name: cli-bin
-              subPath: 04-fix-olares-cli-perms
-              readOnly: true
             - mountPath: /dev/shm
               name: dshm
             {{- if eq (toString .Values.olaresEnv.ALLOW_HOME_DIR_ACCESS) "true" }}
@@ -461,14 +386,20 @@ spec:
             - mountPath: /home/userdata/external/
               name: olares-external-dir
             {{- end }}
+          # Hardening (gateway only for now; validate before extending). Caps are
+          # the minimal set s6's root stage needs to chown + s6-setuidgid-drop.
           securityContext:
             allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: ["ALL"]
+              add: ["CHOWN", "DAC_OVERRIDE", "FOWNER", "FSETID", "SETUID", "SETGID", "KILL"]
 
-        # Dashboard sidecar: web UI on 9119, reads gateway health on localhost.
-        # --insecure: allow non-localhost bind behind the Olares SSO ingress.
-        # The web TUI WS gate is relaxed by the 03-allow-dashboard-ws cont-init.
+        # Dashboard sidecar: web UI on 9119. --insecure binds non-localhost
+        # behind the Olares SSO ingress.
         - name: dashboard
-          image: "beclab/nousresearch-hermes-agent:v2026.5.29.2"
+          image: "beclab/harveyff-hermes-agent:v2026.6.5-uid1000"
           imagePullPolicy: IfNotPresent
           args:
             - "dashboard"
@@ -476,7 +407,6 @@ spec:
             - "0.0.0.0"
             - "--insecure"
             - "--no-open"
-            - "--tui"
           ports:
             - name: dashboard
               containerPort: 9119
@@ -484,14 +414,8 @@ spec:
           env:
             - name: HOME
               value: /opt/data
-            # uid/gid s6 maps the hermes user to (Olares platform default 1000).
-            - name: HERMES_UID
-              value: "1000"
-            - name: HERMES_GID
-              value: "1000"
             - name: GATEWAY_HEALTH_URL
               value: "http://localhost:8642"
-            # Match gateway PATH so dashboard-side `hermes ...` sees brew.
             - name: HOMEBREW_PREFIX
               value: /home/linuxbrew/.linuxbrew
             - name: HOMEBREW_NO_AUTO_UPDATE
@@ -538,15 +462,6 @@ spec:
               name: cli-bin
               subPath: 02-reconcile-profiles
               readOnly: true
-            # Relax the dashboard WS loopback gate at boot.
-            - mountPath: /etc/cont-init.d/03-allow-dashboard-ws
-              name: cli-bin
-              subPath: 03-allow-dashboard-ws
-              readOnly: true
-            - mountPath: /etc/cont-init.d/04-fix-olares-cli-perms
-              name: cli-bin
-              subPath: 04-fix-olares-cli-perms
-              readOnly: true
             {{- if eq (toString .Values.olaresEnv.ALLOW_HOME_DIR_ACCESS) "true" }}
             - mountPath: /home/userdata/home/
               name: olares-home-dir
@@ -558,11 +473,10 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
 
-        # Workspace for the TUI: `sleep infinity` so the terminal entrance can
-        # `kubectl exec` in and run `hermes setup` / `hermes`. `args` lets the
-        # image entrypoint bootstrap /opt/data first.
+        # Workspace for the TUI: `sleep infinity` so the terminal can exec in
+        # and run `hermes setup` / `hermes`.
         - name: hermesagent
-          image: "beclab/nousresearch-hermes-agent:v2026.5.29.2"
+          image: "beclab/harveyff-hermes-agent:v2026.6.5-uid1000"
           imagePullPolicy: IfNotPresent
           args: ["sleep", "infinity"]
           env:
@@ -570,11 +484,6 @@ spec:
               value: xterm-256color
             - name: HOME
               value: /opt/data
-            # uid/gid s6 maps the hermes user to (Olares platform default 1000).
-            - name: HERMES_UID
-              value: "1000"
-            - name: HERMES_GID
-              value: "1000"
             - name: HERMES_HOME
               value: /opt/data
             - name: HOMEBREW_PREFIX
@@ -617,10 +526,6 @@ spec:
             - mountPath: /etc/profile.d/99-drop-to-hermes.sh
               name: cli-bin
               subPath: drop-to-hermes
-              readOnly: true
-            - mountPath: /etc/cont-init.d/04-fix-olares-cli-perms
-              name: cli-bin
-              subPath: 04-fix-olares-cli-perms
               readOnly: true
             {{- if eq (toString .Values.olaresEnv.ALLOW_HOME_DIR_ACCESS) "true" }}
             - mountPath: /home/userdata/home/
@@ -677,8 +582,7 @@ spec:
   selector:
     io.kompose.service: hermesagent
 ---
-# Gateway OpenAI-compatible API service. Always created (stable DNS for the
-# `api` entrance) even though the gateway only binds when the API key is set.
+# Gateway OpenAI-compatible API service (stable DNS; binds only when API key set).
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Switch to a pre-baked UID/GID 1000 image (beclab/harveyff-hermes-agent:v2026.6.5-uid1000, Hermes v0.16.0) instead of remapping identity at boot via HERMES_UID. Running the stock UID-10000 image as 1000 made the s6 stage2 hook chown ~47k build-tree files on every boot, triggering an overlayfs copy-up storm that hung the container during cont-init.

- Drop HERMES_UID/HERMES_GID env from all three containers (identity now baked in image).

- Remove obsolete startup workarounds fixed upstream in v0.16.0: dashboard WebSocket loopback patch (03-allow-dashboard-ws), olares-cli perms repair (04-fix-olares-cli-perms), and the removed --tui dashboard flag.

- Streamline init: drop redundant olares-cli discovery/CDN logic.

- Harden the gateway container with seccompProfile RuntimeDefault and a minimal Linux capability set.

- Add hermesagent/Dockerfile: thin overlay on nousresearch/hermes-agent that re-bakes hermes to UID/GID 1000 (parameterized via HERMES_VERSION/TARGET_UID/TARGET_GID build args).

- Bump chart version 1.3.14 -> 1.3.15; appVersion/versionName 0.15.2 -> 0.16.0.

### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
> The title of your application appears on Market.

### Description
> Brief description about your application here. 
>
> For app updates, please describe the changes.

### Statement
- [ ] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
