### PR TITLE
[UPDATE][vllmllmbasev3][1.2.7]persist vLLM and CUDA caches

### DIFF
--- a/vllmllmbasev3/Chart.yaml
+++ b/vllmllmbasev3/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.23.0
 description: Generic vLLM + llm-init base; the model is supplied at install time via env
 name: vllmllmbasev3
 type: application
-version: 1.2.6
+version: 1.2.7

--- a/vllmllmbasev3/OlaresManifest.yaml
+++ b/vllmllmbasev3/OlaresManifest.yaml
@@ -7,7 +7,7 @@ metadata:
   description: "Generic vLLM + llm-init base. Pick any HF model at install via env."
   appid: vllmllmbasev3
   title: vLLM LLM Base (llm-init)
-  version: '1.2.6'
+  version: '1.2.7'
   categories:
     - AI
 entrances:

--- a/vllmllmbasev3/templates/llm-init.yaml
+++ b/vllmllmbasev3/templates/llm-init.yaml
@@ -92,7 +92,7 @@ spec:
           command:
             - sh
             - -c
-            - "chown 1000:1000 /cache/hf/hub /run/llm-init || true"
+            - "mkdir -p /cache/hf/hub/vllm-cache /cache/hf/hub/.nv/ComputeCache && chown 1000:1000 /cache/hf/hub /cache/hf/hub/vllm-cache /cache/hf/hub/.nv /cache/hf/hub/.nv/ComputeCache /run/llm-init || true"
           volumeMounts:
             - name: hf-cache
               mountPath: /cache/hf/hub

--- a/vllmllmbasev3/templates/vllm.yaml
+++ b/vllmllmbasev3/templates/vllm.yaml
@@ -28,7 +28,8 @@
 # the shared run-state dir, then serves --model "$MODEL_NAME" on :8000. llm-init
 # reverse-proxies http://vllm:8000 via the "vllm" Service below.
 # Shared hostPath volumes (read-only here, llm-init owns writes): hf-cache
-# (/cache/hf/hub), run-state (sentinel handshake).
+# (/cache/hf/hub), run-state (sentinel handshake). vllm-cache and .nv/ComputeCache
+# live as subdirs of the same appCommon/huggingface store (siblings to models--*).
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -83,6 +84,8 @@ spec:
               value: "3600"
             - name: ENGINE_ARGS
               value: "{{ $engineArgs }}"
+            - name: VLLM_CACHE_ROOT
+              value: /cache/vllm
             - name: PYTHONUNBUFFERED
               value: "1"
             - name: PGID
@@ -102,6 +105,12 @@ spec:
             - name: hf-cache
               mountPath: /cache/hf/hub
               readOnly: true
+            - name: hf-cache
+              mountPath: /cache/vllm
+              subPath: vllm-cache
+            - name: hf-cache
+              mountPath: /root/.nv/ComputeCache
+              subPath: .nv/ComputeCache
             - name: run-state
               mountPath: /run/llm-init
               readOnly: true


### PR DESCRIPTION
…gingface

Mount vllm-cache and .nv/ComputeCache as subdirs of the shared HF model store (same appCommon/huggingface volume). Set VLLM_CACHE_ROOT=/cache/vllm so torch.compile artifacts survive Pod restarts and shorten cold starts.

### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
> The title of your application appears on Market.

### Description
> Brief description about your application here. 
>
> For app updates, please describe the changes.

### Statement
- [ ] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
