### PR TITLE
[UPDATE][sglangllmbasev3][1.2.7] Persist SGLang JIT and CUDA caches under HF store

### DIFF
--- a/sglangllmbasev3/Chart.yaml
+++ b/sglangllmbasev3/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.5.13.post1
 description: Generic SGLang + llm-init base; the model is supplied at install time via env
 name: sglangllmbasev3
 type: application
-version: 1.2.6
+version: 1.2.7

--- a/sglangllmbasev3/OlaresManifest.yaml
+++ b/sglangllmbasev3/OlaresManifest.yaml
@@ -7,7 +7,7 @@ metadata:
   description: "Generic SGLang + llm-init base. Pick any HF model at install via env."
   appid: sglangllmbasev3
   title: SGLang LLM Base (llm-init)
-  version: '1.2.6'
+  version: '1.2.7'
   categories:
     - AI
 entrances:

--- a/sglangllmbasev3/templates/llm-init.yaml
+++ b/sglangllmbasev3/templates/llm-init.yaml
@@ -82,7 +82,7 @@ spec:
           command:
             - sh
             - -c
-            - "chown 1000:1000 /cache/hf/hub /run/llm-init || true"
+            - "mkdir -p /cache/hf/hub/sglang-cache /cache/hf/hub/.nv/ComputeCache && chown 1000:1000 /cache/hf/hub /cache/hf/hub/sglang-cache /cache/hf/hub/.nv /cache/hf/hub/.nv/ComputeCache /run/llm-init || true"
           volumeMounts:
             - name: hf-cache
               mountPath: /cache/hf/hub

--- a/sglangllmbasev3/templates/sglang.yaml
+++ b/sglangllmbasev3/templates/sglang.yaml
@@ -28,6 +28,9 @@
 # SGLang engine Deployment (GPU). wrappers/sglang.sh blocks on the sentinel
 # llm-init writes, reads model_path, then execs launch_server on :30000.
 # llm-init reverse-proxies at http://sglang:30000 — Service name MUST be "sglang".
+# Shared hostPath volumes (read-only here, llm-init owns writes): hf-cache
+# (/cache/hf/hub), run-state (sentinel handshake). sglang-cache and .nv/ComputeCache
+# live as subdirs of the same appCommon/huggingface store (siblings to models--*).
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -82,6 +85,8 @@ spec:
               value: "3600"
             - name: ENGINE_ARGS
               value: "{{ $engineArgs }}"
+            - name: SGLANG_JIT_CACHE_ROOT
+              value: /cache/sglang
             - name: PYTHONUNBUFFERED
               value: "1"
             - name: PGID
@@ -97,6 +102,12 @@ spec:
             - name: hf-cache
               mountPath: /cache/hf/hub
               readOnly: true
+            - name: hf-cache
+              mountPath: /cache/sglang
+              subPath: sglang-cache
+            - name: hf-cache
+              mountPath: /root/.nv/ComputeCache
+              subPath: .nv/ComputeCache
             - name: run-state
               mountPath: /run/llm-init
               readOnly: true


### PR DESCRIPTION
…mmon/huggingface

Mount sglang-cache and .nv/ComputeCache as subdirs of the shared HF model store (same appCommon/huggingface volume). Set SGLANG_JIT_CACHE_ROOT=/cache/sglang so torch.compile / JIT artifacts survive Pod restarts and shorten cold starts.

### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
> The title of your application appears on Market.

### Description
> Brief description about your application here. 
>
> For app updates, please describe the changes.

### Statement
- [ ] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
