### PR TITLE
[UPDATE][codex][1.0.3]bump Codex CLI to 0.141.0 and base image to Node 20

### DIFF
--- a/codex/Chart.yaml
+++ b/codex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: '0.125.0'
+appVersion: '0.141.0'
 description: OpenAI's lightweight coding agent that runs in your terminal
 name: codex
 type: application
-version: 1.0.2
+version: 1.0.3

--- a/codex/OlaresManifest.yaml
+++ b/codex/OlaresManifest.yaml
@@ -6,7 +6,7 @@ metadata:
   description: OpenAI's lightweight coding agent that runs in your terminal
   appid: codex
   title: Codex CLI
-  version: 1.0.2
+  version: 1.0.3
   categories:
   - Developer Tools
   - Productivity_v112
@@ -20,7 +20,7 @@ entrances:
   openMethod: window
   authLevel: internal
 spec:
-  versionName: '0.125.0'
+  versionName: '0.141.0'
   fullDescription: |
     **Overview**
     Codex CLI is OpenAI's lightweight, open-source coding agent that runs locally in your terminal. It understands your codebase, executes routine tasks through natural language, and helps you ship faster while staying in flow.
@@ -37,29 +37,19 @@ spec:
     Open the `Codex CLI` entrance and run `codex` to launch the OAuth login flow ("Sign in with ChatGPT"), or set `OPENAI_API_KEY` in the app environment variables and restart.
 
   upgradeDescription: |
-    Terminal upgraded to `beclab/terminal:v0.0.11`: file upload support — paste
-    screenshots, drag-and-drop files, or click the upload button to send files
-    into the terminal session.
+    Codex CLI upgraded from 0.125.0 to 0.141.0. The native binary is
+    re-downloaded automatically on the next pod start (versioned install
+    sentinel), so the upgrade requires no manual steps.
 
-    Workspace memory raised (limit 16Gi -> 24Gi, request 256Mi -> 2Gi) to reduce
-    out-of-memory crashes during heavy agent/build sessions.
+    Base image `beclab/harveyff-codex-base` upgraded to 0.5.5:
+    - Node.js upgraded from 18 to 20 LTS (via NodeSource), satisfying modern
+      CLIs that require node >= 20.12.0.
+    - npm global prefix set to `/opt/data/.local` (on the persistent PVC), so
+      `npm install -g` works as the non-root user and survives pod restarts —
+      no more EACCES on `/usr/local`.
 
-    Base image `beclab/harveyff-codex-base` upgraded to 0.5.4.
-
-    New:
-    - Built-in `olares-cli` (vendor binary, full command set) on PATH.
-    - Olares skill pack (cluster, dashboard, files, market, settings, shared)
-      copied into `~/.codex/skills` at pod start via `init-skills`, so the agent
-      can operate Olares without manual setup.
-    - Expanded toolbox: `gh`, `ping`/`lsof`, `lrzsz` (sz/rz), `tree`, `nano`,
-      `tcpdump`, `traceroute`, `httpie`, `aria2`, and common debug/network tools.
-    - Optional Docker-in-Docker sidecar (`ENABLE_DIND`, default on): `docker` /
-      `docker compose` in the terminal (privileged sidecar; extra app-data disk).
-
-    Skills note: `init-skills` only refreshes directories that match the built-in
-    Olares pack (same folder names). Your other skills under `~/.codex/skills` are
-    left untouched. If you edited an Olares skill in place, those changes are
-    overwritten on the next pod restart when the directory name matches.
+    Note: if a project relies on native (node-gyp) modules built against
+    Node 18, run `npm rebuild` in that project after the upgrade.
 
   developer: OpenAI
   website: https://chatgpt.com/codex

--- a/codex/docker/Dockerfile
+++ b/codex/docker/Dockerfile
@@ -15,7 +15,7 @@
 # Build & push:
 #   docker buildx build \
 #     --platform linux/amd64,linux/arm64 \
-#     -t beclab/harveyff-codex-base:0.5.4 \
+#     -t beclab/harveyff-codex-base:0.5.5 \
 #     --push .
 # syntax=docker/dockerfile:1.7
 
@@ -92,8 +92,6 @@ RUN apt-get update \
         python3-pip \
         python3-venv \
         pipx \
-        nodejs \
-        npm \
         golang-go \
         rustc \
         cargo \
@@ -184,6 +182,14 @@ RUN apt-get update \
  && mkdir -p /opt/data \
  && chown -R 1000:1000 /opt/data
 
+# Node 20 LTS via NodeSource. Ubuntu 24.04's nodejs is v18.19.1, which is
+# too old for some CLIs (e.g. @larksuite/cli needs node >= 20.12.0). This
+# ships node + npm under /usr/local, replacing the distro packages above.
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/* \
+ && node --version && npm --version
+
 COPY --from=olares-assets /out/bin/olares-cli /usr/local/bin/olares-cli
 RUN chmod 755 /usr/local/bin/olares-cli \
  && ( /usr/local/bin/olares-cli --version || /usr/local/bin/olares-cli version || true )
@@ -200,6 +206,8 @@ WORKDIR /opt/data
 ENV HOME=/opt/data \
     PATH=/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     TERM=xterm-256color \
-    PIP_BREAK_SYSTEM_PACKAGES=1
+    PIP_BREAK_SYSTEM_PACKAGES=1 \
+    NPM_CONFIG_PREFIX=/opt/data/.local \
+    NPM_CONFIG_CACHE=/opt/data/.npm
 
 CMD ["bash"]

--- a/codex/docker/README.md
+++ b/codex/docker/README.md
@@ -45,13 +45,13 @@ Codex bundles its own.
 
 ```bash
 # Single-arch (local dev)
-docker build -t beclab/harveyff-codex-base:0.5.4 .
+docker build -t beclab/harveyff-codex-base:0.5.5 .
 
 # Multi-arch release (recommended, matches chart supportArch)
 docker buildx create --use --name codex-builder || true
 docker buildx build \
   --platform linux/amd64,linux/arm64 \
-  -t beclab/harveyff-codex-base:0.5.4 \
+  -t beclab/harveyff-codex-base:0.5.5 \
   --push .
 ```
 
@@ -59,7 +59,7 @@ docker buildx build \
 
 When bumping apt dependencies or base Ubuntu:
 
-1. Increment the tag (e.g. `0.5.4 -> 0.5.5`).
+1. Increment the tag (e.g. `0.5.5 -> 0.5.6`).
 2. Update all references in `codex/templates/deployment.yaml`
    (init-skills + init-install-codex + main container).
 3. Bump `version` in `codex/Chart.yaml` and `metadata.version` in

--- a/codex/i18n/en-US/OlaresManifest.yaml
+++ b/codex/i18n/en-US/OlaresManifest.yaml
@@ -17,26 +17,16 @@ spec:
     **First-time Setup**
     Open the `Codex CLI` entrance and run `codex` to launch the OAuth login flow ("Sign in with ChatGPT"), or set `OPENAI_API_KEY` in the app environment variables and restart.
   upgradeDescription: |
-    Terminal upgraded to `beclab/terminal:v0.0.11`: file upload support — paste
-    screenshots, drag-and-drop files, or click the upload button to send files
-    into the terminal session.
+    Codex CLI upgraded from 0.125.0 to 0.141.0. The native binary is
+    re-downloaded automatically on the next pod start (versioned install
+    sentinel), so the upgrade requires no manual steps.
 
-    Workspace memory raised (limit 16Gi -> 24Gi, request 256Mi -> 2Gi) to reduce
-    out-of-memory crashes during heavy agent/build sessions.
+    Base image `beclab/harveyff-codex-base` upgraded to 0.5.5:
+    - Node.js upgraded from 18 to 20 LTS (via NodeSource), satisfying modern
+      CLIs that require node >= 20.12.0.
+    - npm global prefix set to `/opt/data/.local` (on the persistent PVC), so
+      `npm install -g` works as the non-root user and survives pod restarts —
+      no more EACCES on `/usr/local`.
 
-    Base image `beclab/harveyff-codex-base` upgraded to 0.5.4.
-
-    New:
-    - Built-in `olares-cli` (vendor binary, full command set) on PATH.
-    - Olares skill pack (cluster, dashboard, files, market, settings, shared)
-      copied into `~/.codex/skills` at pod start via `init-skills`, so the agent
-      can operate Olares without manual setup.
-    - Expanded toolbox: `gh`, `ping`/`lsof`, `lrzsz` (sz/rz), `tree`, `nano`,
-      `tcpdump`, `traceroute`, `httpie`, `aria2`, and common debug/network tools.
-    - Optional Docker-in-Docker sidecar (`ENABLE_DIND`, default on): `docker` /
-      `docker compose` in the terminal (privileged sidecar; extra app-data disk).
-
-    Skills note: `init-skills` only refreshes directories that match the built-in
-    Olares pack (same folder names). Your other skills under `~/.codex/skills` are
-    left untouched. If you edited an Olares skill in place, those changes are
-    overwritten on the next pod restart when the directory name matches.
+    Note: if a project relies on native (node-gyp) modules built against
+    Node 18, run `npm rebuild` in that project after the upgrade.

--- a/codex/i18n/zh-CN/OlaresManifest.yaml
+++ b/codex/i18n/zh-CN/OlaresManifest.yaml
@@ -17,23 +17,15 @@ spec:
     **首次设置**
     打开 `Codex CLI` 入口并运行 `codex`，开启 OAuth 登录流程（“使用 ChatGPT 登录”）；也可在应用环境变量中配置 `OPENAI_API_KEY`，然后重启应用。
   upgradeDescription: |
-    终端升级至 `beclab/terminal:v0.0.11`：新增文件上传功能——可粘贴截图、拖拽文件，
-    或点击上传按钮将文件发送到终端会话。
+    Codex CLI 从 0.125.0 升级至 0.141.0。原生二进制会在下次 Pod 启动时自动重新
+    下载（安装哨兵文件带版本号），升级无需任何手动操作。
 
-    工作区内存上调（上限 16Gi → 24Gi，请求 256Mi → 2Gi），减少高强度 Agent/构建
-    场景下的内存不足崩溃。
+    基础镜像 `beclab/harveyff-codex-base` 升级至 0.5.5：
+    - Node.js 从 18 升级到 20 LTS（通过 NodeSource），满足要求 node >= 20.12.0
+      的新版 CLI。
+    - npm 全局目录（prefix）指向持久化 PVC 上的 `/opt/data/.local`，非 root 用户
+      执行 `npm install -g` 可直接成功且重启不丢失——不再出现 `/usr/local` 的
+      EACCES 权限错误。
 
-    基础镜像 `beclab/harveyff-codex-base` 升级至 0.5.4。
-
-    新增：
-    - 内置 `olares-cli`（vendor 裸二进制，完整子命令）已加入 PATH。
-    - 启动时由 `init-skills` 将 Olares 技能包（cluster、dashboard、files、market、
-      settings、shared）复制到 `~/.codex/skills`，Agent 可开箱操作 Olares。
-    - 扩充工具箱：`gh`、`ping`/`lsof`、`lrzsz`（sz/rz）、`tree`、`nano`、`tcpdump`、
-      `traceroute`、`httpie`、`aria2` 及常用网络/调试工具。
-    - 可选 Docker-in-Docker 边车（`ENABLE_DIND`，默认开启）：终端内可用 `docker` /
-      `docker compose`（特权边车，额外占用 app data 磁盘）。
-
-    关于 Skills：`init-skills` 仅按目录名覆盖镜像内置的 Olares 技能（同名目录会
-    在每次 Pod 启动时用镜像版本替换）；`~/.codex/skills` 下其余自定义技能不会被
-    删除。若你曾就地修改过某个 Olares 技能目录，下次重启后会被还原为镜像自带版本。
+    注意：若某个项目依赖按 Node 18 编译的原生（node-gyp）模块，升级后请在该项目
+    内执行 `npm rebuild`。

--- a/codex/templates/deployment.yaml
+++ b/codex/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
         # Flatten Olares skills from /skills-staging into Codex's
         # user skills dir (~/.codex/skills = /opt/data/.codex/skills).
         - name: init-skills
-          image: "beclab/harveyff-codex-base:0.5.4"
+          image: "beclab/harveyff-codex-base:0.5.5"
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0
@@ -111,7 +111,7 @@ spec:
         # subsequent Pod starts skip the download; bumping appVersion
         # in Chart.yaml automatically forces a re-download.
         - name: init-install-codex
-          image: "beclab/harveyff-codex-base:0.5.4"
+          image: "beclab/harveyff-codex-base:0.5.5"
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
@@ -216,7 +216,7 @@ spec:
         # login / non-login / interactive / non-interactive shells all
         # see the codex binary on PATH.
         - name: codex
-          image: "beclab/harveyff-codex-base:0.5.4"
+          image: "beclab/harveyff-codex-base:0.5.5"
           imagePullPolicy: IfNotPresent
           workingDir: /opt/data
           securityContext:


### PR DESCRIPTION
Upgrade the Codex CLI native binary from 0.125.0 to 0.141.0 (downloaded at pod start via the versioned install sentinel, no manual steps).

Base image beclab/harveyff-codex-base bumped 0.5.4 -> 0.5.5:
- Node.js 18 -> 20 LTS via NodeSource, so CLIs requiring node >= 20.12.0 (e.g. @larksuite/cli) install cleanly.
- npm global prefix set to /opt/data/.local on the persistent PVC, letting the non-root user run `npm install -g` without EACCES on /usr/local and keeping global packages across pod restarts.

Chart version 1.0.2 -> 1.0.3; app/manifest versions and changelogs updated.

### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
> The title of your application appears on Market.

### Description
> Brief description about your application here. 
>
> For app updates, please describe the changes.

### Statement
- [ ] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
