### PR TITLE
[UPDATE][claudecode][0.1.8]pin claude 2.1.185, Node 20 base image

### DIFF
--- a/claudecode/Chart.yaml
+++ b/claudecode/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: '2.1.161'
+appVersion: '2.1.185'
 description: Anthropic's official agentic coding CLI that lives in your terminal
 name: claudecode
 type: application
-version: 0.1.7
+version: 0.1.8

--- a/claudecode/OlaresManifest.yaml
+++ b/claudecode/OlaresManifest.yaml
@@ -7,7 +7,7 @@ metadata:
   description: Anthropic's official agentic coding CLI that lives in your terminal
   appid: claudecode
   title: Claude Code
-  version: 0.1.7
+  version: 0.1.8
   categories:
   - Developer Tools
   - Productivity_v112
@@ -21,7 +21,7 @@ entrances:
   openMethod: window
   authLevel: internal
 spec:
-  versionName: '2.1.161'
+  versionName: '2.1.185'
   fullDescription: |
     **Overview**
     Claude Code is Anthropic's official agentic coding tool that lives in your terminal. It understands your codebase, executes routine tasks through natural language, and helps you move fast while staying in flow.
@@ -49,20 +49,19 @@ spec:
     These vars are conditionally injected: blank strings and `false` toggles are *not* placed into the container env, so Claude Code sees them as truly unset (which is required — it treats `CLAUDE_CODE_USE_*` by presence, not value).
 
   upgradeDescription: |
-    Upgrade claudecode version to 2.1.161
-    Support Docker-in-Docker, add olares-cli and skills, add file upload support in terminal
+    Claude Code pinned to 2.1.185. The installed version now tracks the chart
+    `appVersion`: the binary is re-installed on the next pod start (versioned
+    install sentinel), so the upgrade requires no manual steps.
 
-    Highlights:
-    - Built-in `olares-cli` (vendor binary, full command set) on PATH.
-    - Olares skill pack (cluster, dashboard, files, market, settings, shared)
-      copied into `~/.claude/skills` at pod start via `init-skills`, so the agent
-      can operate Olares without manual setup.
-    - Docker-in-Docker sidecar (`ENABLE_DIND`, default on): run `docker build`,
-      `docker compose`, and containerized dev stacks from the terminal.
-    - Expanded toolbox: `gh`, `ping`/`lsof`, `lrzsz` (sz/rz), `tree`, `nano`,
-      `tcpdump`, `traceroute`, `httpie`, `aria2`, and common debug/network tools.
+    Base image `beclab/harveyff-claudecode-base` upgraded to 0.5.4:
+    - Node.js upgraded from 18 to 20 LTS (via NodeSource), satisfying modern
+      CLIs that require node >= 20.12.0.
+    - npm global prefix set to `/opt/data/.local` (on the persistent PVC), so
+      `npm install -g` works as the non-root user and survives pod restarts —
+      no more EACCES on `/usr/local`.
 
-    View full changelog in claudecode: https://code.claude.com/docs/en/changelog
+    Note: if a project relies on native (node-gyp) modules built against
+    Node 18, run `npm rebuild` in that project after the upgrade.
 
   developer: Anthropic
   website: https://code.claude.com

--- a/claudecode/docker/Dockerfile
+++ b/claudecode/docker/Dockerfile
@@ -15,7 +15,7 @@
 # Build & push:
 #   docker buildx build \
 #     --platform linux/amd64,linux/arm64 \
-#     -t beclab/harveyff-claudecode-base:0.2.0 \
+#     -t beclab/harveyff-claudecode-base:0.5.4 \
 #     --push .
 # syntax=docker/dockerfile:1.7
 
@@ -91,8 +91,6 @@ RUN apt-get update \
         python3-pip \
         python3-venv \
         pipx \
-        nodejs \
-        npm \
         golang-go \
         rustc \
         cargo \
@@ -183,6 +181,14 @@ RUN apt-get update \
  && mkdir -p /opt/data \
  && chown -R 1000:1000 /opt/data
 
+# Node 20 LTS via NodeSource. Ubuntu 24.04's nodejs is v18.19.1, which is
+# too old for some CLIs (e.g. @larksuite/cli needs node >= 20.12.0). This
+# ships node + npm under /usr/local, replacing the distro packages above.
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/* \
+ && node --version && npm --version
+
 COPY --from=olares-assets /out/bin/olares-cli /usr/local/bin/olares-cli
 RUN chmod 755 /usr/local/bin/olares-cli \
  && ( /usr/local/bin/olares-cli --version || /usr/local/bin/olares-cli version || true )
@@ -200,6 +206,8 @@ ENV HOME=/opt/data \
     PATH=/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     TERM=xterm-256color \
     DISABLE_AUTOUPDATER=1 \
-    PIP_BREAK_SYSTEM_PACKAGES=1
+    PIP_BREAK_SYSTEM_PACKAGES=1 \
+    NPM_CONFIG_PREFIX=/opt/data/.local \
+    NPM_CONFIG_CACHE=/opt/data/.npm
 
 CMD ["bash"]

--- a/claudecode/docker/README.md
+++ b/claudecode/docker/README.md
@@ -44,13 +44,13 @@ Claude Code bundles its own.
 
 ```bash
 # Single-arch (local dev)
-docker build -t beclab/harveyff-claudecode-base:0.2.0 .
+docker build -t beclab/harveyff-claudecode-base:0.5.4 .
 
 # Multi-arch release (recommended, matches chart supportArch)
 docker buildx create --use --name claudecode-builder || true
 docker buildx build \
   --platform linux/amd64,linux/arm64 \
-  -t beclab/harveyff-claudecode-base:0.5.3 \
+  -t beclab/harveyff-claudecode-base:0.5.4 \
   --push .
 ```
 
@@ -58,7 +58,7 @@ docker buildx build \
 
 When bumping apt dependencies or base Ubuntu:
 
-1. Increment the tag (e.g. `0.5.2 -> 0.5.3`).
+1. Increment the tag (e.g. `0.5.3 -> 0.5.4`).
 2. Update both references in `claudecode/templates/deployment.yaml`
    (initContainer + main container).
 3. Bump `version` in `claudecode/Chart.yaml` and `metadata.version` in

--- a/claudecode/i18n/en-US/OlaresManifest.yaml
+++ b/claudecode/i18n/en-US/OlaresManifest.yaml
@@ -28,17 +28,16 @@ spec:
 
     These vars are conditionally injected: blank strings and `false` toggles are *not* placed into the container env, so Claude Code sees them as truly unset (which is required — it treats `CLAUDE_CODE_USE_*` by presence, not value).
   upgradeDescription: |
-    Upgrade claudecode version to 2.1.161
-    Support Docker-in-Docker, add olares-cli and skills, add file upload support in terminal
+    Claude Code pinned to 2.1.185. The installed version now tracks the chart
+    `appVersion`: the binary is re-installed on the next pod start (versioned
+    install sentinel), so the upgrade requires no manual steps.
 
-    Highlights:
-    - Built-in `olares-cli` (vendor binary, full command set) on PATH.
-    - Olares skill pack (cluster, dashboard, files, market, settings, shared)
-      copied into `~/.claude/skills` at pod start via `init-skills`, so the agent
-      can operate Olares without manual setup.
-    - Docker-in-Docker sidecar (`ENABLE_DIND`, default on): run `docker build`,
-      `docker compose`, and containerized dev stacks from the terminal.
-    - Expanded toolbox: `gh`, `ping`/`lsof`, `lrzsz` (sz/rz), `tree`, `nano`,
-      `tcpdump`, `traceroute`, `httpie`, `aria2`, and common debug/network tools.
+    Base image `beclab/harveyff-claudecode-base` upgraded to 0.5.4:
+    - Node.js upgraded from 18 to 20 LTS (via NodeSource), satisfying modern
+      CLIs that require node >= 20.12.0.
+    - npm global prefix set to `/opt/data/.local` (on the persistent PVC), so
+      `npm install -g` works as the non-root user and survives pod restarts —
+      no more EACCES on `/usr/local`.
 
-    View full changelog in claudecode: https://code.claude.com/docs/en/changelog
+    Note: if a project relies on native (node-gyp) modules built against
+    Node 18, run `npm rebuild` in that project after the upgrade.

--- a/claudecode/i18n/zh-CN/OlaresManifest.yaml
+++ b/claudecode/i18n/zh-CN/OlaresManifest.yaml
@@ -28,17 +28,15 @@ spec:
 
     上述变量在 chart 中按条件注入：留空字符串或 `false` 时**不会**写入容器环境，Claude Code 会视其为真正"未设置"（必须如此——它对 `CLAUDE_CODE_USE_*` 的判断是按是否存在，而不是按值）。
   upgradeDescription: |
-    升级 claudecode 版本至 2.1.161
-    支持 Docker-in-Docker，新增 olares-cli 与技能包，终端内增加文件上传支持
+    Claude Code 锁定到 2.1.185。安装版本现在跟随 chart 的 `appVersion`：二进制会在
+    下次 Pod 启动时重新安装（安装哨兵文件带版本号），升级无需任何手动操作。
 
-    主要亮点：
-    - 内置 `olares-cli`（官方发行版二进制，完整命令集），已添加至 PATH。
-    - Olares 技能包（cluster、dashboard、files、market、settings、shared）
-      会在 Pod 启动时通过 `init-skills` 自动复制到 `~/.claude/skills`，
-      让 Agent 可直接操作 Olares，无需手动配置。
-    - 支持 Docker-in-Docker 边车（`ENABLE_DIND`，默认开启）：可在终端使用 `docker build`、
-      `docker compose` 及容器化开发方案。
-    - 工具箱扩展：包含 `gh`、`ping`/`lsof`、`lrzsz`（sz/rz）、`tree`、`nano`、
-      `tcpdump`、`traceroute`、`httpie`、`aria2` 及常见调试/网络工具。
+    基础镜像 `beclab/harveyff-claudecode-base` 升级至 0.5.4：
+    - Node.js 从 18 升级到 20 LTS（通过 NodeSource），满足要求 node >= 20.12.0
+      的新版 CLI。
+    - npm 全局目录（prefix）指向持久化 PVC 上的 `/opt/data/.local`，非 root 用户
+      执行 `npm install -g` 可直接成功且重启不丢失——不再出现 `/usr/local` 的
+      EACCES 权限错误。
 
-    查看 claudecode 完整更新日志：https://code.claude.com/docs/en/changelog
+    注意：若某个项目依赖按 Node 18 编译的原生（node-gyp）模块，升级后请在该项目
+    内执行 `npm rebuild`。

--- a/claudecode/templates/deployment.yaml
+++ b/claudecode/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
         # Flatten Olares skills from /skills-staging into Claude Code's
         # user skills dir (~/.claude/skills = /opt/data/.claude/skills).
         - name: init-skills
-          image: "beclab/harveyff-claudecode-base:0.5.3"
+          image: "beclab/harveyff-claudecode-base:0.5.4"
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0
@@ -82,7 +82,7 @@ spec:
         # only writes under $HOME. A sentinel file makes subsequent
         # Pod starts skip the download.
         - name: init-install-claude
-          image: "beclab/harveyff-claudecode-base:0.5.3"
+          image: "beclab/harveyff-claudecode-base:0.5.4"
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
@@ -98,16 +98,18 @@ spec:
               value: /usr/lib/jvm/java-21-openjdk-current
             - name: DISABLE_AUTOUPDATER
               value: "1"
+            - name: CLAUDE_VERSION
+              value: "{{ .Chart.AppVersion }}"
           command:
             - bash
             - -c
             - |
               set -euo pipefail
-              SENTINEL="$HOME/.install-state/install-complete"
+              SENTINEL="$HOME/.install-state/install-complete-${CLAUDE_VERSION}"
               mkdir -p "$HOME/.install-state" "$HOME/.local/bin"
 
               if [ -x "$HOME/.local/bin/claude" ] && [ -f "$SENTINEL" ]; then
-                echo "[init-install-claude] cached binary found (installed $(cat "$SENTINEL"))"
+                echo "[init-install-claude] cached claude ${CLAUDE_VERSION} found (installed $(cat "$SENTINEL"))"
                 "$HOME/.local/bin/claude" --version
                 exit 0
               fi
@@ -120,8 +122,10 @@ spec:
                 https://claude.ai/install.sh -o "$INSTALLER"
               echo "[init-install-claude] installer downloaded ($(wc -c < "$INSTALLER") bytes)"
 
-              echo "[init-install-claude] running installer..."
-              bash "$INSTALLER"
+              # Pin the installed version to the chart's appVersion. The installer
+              # accepts: install.sh [stable|latest|VERSION].
+              echo "[init-install-claude] running installer for version ${CLAUDE_VERSION}..."
+              bash "$INSTALLER" "${CLAUDE_VERSION}"
 
               if [ ! -x "$HOME/.local/bin/claude" ]; then
                 echo "[init-install-claude] installer completed but binary not found at $HOME/.local/bin/claude" >&2
@@ -130,7 +134,7 @@ spec:
               fi
 
               date -u +%Y-%m-%dT%H:%M:%SZ > "$SENTINEL"
-              echo "[init-install-claude] installed"
+              echo "[init-install-claude] installed claude ${CLAUDE_VERSION}"
               "$HOME/.local/bin/claude" --version
           resources:
             limits:
@@ -178,7 +182,7 @@ spec:
         # login / non-login / interactive / non-interactive shells all
         # see the claude binary on PATH.
         - name: claudecode
-          image: "beclab/harveyff-claudecode-base:0.5.3"
+          image: "beclab/harveyff-claudecode-base:0.5.4"
           imagePullPolicy: IfNotPresent
           workingDir: /opt/data
           securityContext:


### PR DESCRIPTION
…(Node 20)

Pin the installed Claude Code version to the chart appVersion (2.1.185): init-install-claude now passes $CLAUDE_VERSION to the official installer (install.sh [stable|latest|VERSION]) and uses a versioned install sentinel, so bumping appVersion re-installs the binary on the next pod start.

Base image beclab/harveyff-claudecode-base bumped 0.5.3 -> 0.5.4:
- Node.js 18 -> 20 LTS via NodeSource, so CLIs requiring node >= 20.12.0 (e.g. @larksuite/cli) install cleanly.
- npm global prefix set to /opt/data/.local on the persistent PVC, letting the non-root user run `npm install -g` without EACCES on /usr/local and keeping global packages across pod restarts.

Chart version 0.1.7 -> 0.1.8; manifest versions and changelogs updated.

### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
> The title of your application appears on Market.

### Description
> Brief description about your application here. 
>
> For app updates, please describe the changes.

### Statement
- [ ] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
